### PR TITLE
fix: surface clear error messages when daemon fails to start

### DIFF
--- a/src/lib/daemon-client.ts
+++ b/src/lib/daemon-client.ts
@@ -14,5 +14,6 @@ export {
   updateMaxCostUsd,
   getMaxCostUsd,
   findActiveRun,
+  readDaemonLogTail,
   type DaemonStatus,
 } from "./daemon-status.ts"

--- a/src/lib/daemon-error.test.ts
+++ b/src/lib/daemon-error.test.ts
@@ -1,0 +1,231 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { mkdtemp, rm, mkdir, chmod } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { $ } from "bun"
+import { readDaemonLogTail, getDaemonStatus } from "./daemon-status.ts"
+import { spawnDaemon } from "./daemon-spawn.ts"
+import { releaseLock } from "./daemon-lifecycle.ts"
+
+/** Poll until the daemon PID exits, or timeout. */
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0)
+      // Still alive
+      await new Promise((r) => setTimeout(r, 200))
+    } catch {
+      return true // exited
+    }
+  }
+  return false
+}
+
+// --- readDaemonLogTail unit tests ---
+
+describe("readDaemonLogTail", () => {
+  let tmpDir: string
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "daemon-log-test-"))
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test("returns empty string when daemon.log does not exist", async () => {
+    const result = await readDaemonLogTail(join(tmpDir, "nonexistent"))
+    expect(result).toBe("")
+  })
+
+  test("returns empty string when daemon.log is empty", async () => {
+    const runDir = join(tmpDir, "empty-log")
+    await mkdir(runDir, { recursive: true })
+    await Bun.write(join(runDir, "daemon.log"), "")
+    const result = await readDaemonLogTail(runDir)
+    expect(result).toBe("")
+  })
+
+  test("returns full content for small log", async () => {
+    const runDir = join(tmpDir, "small-log")
+    await mkdir(runDir, { recursive: true })
+    await Bun.write(join(runDir, "daemon.log"), "Daemon fatal error: API key not configured\n")
+    const result = await readDaemonLogTail(runDir)
+    expect(result).toBe("Daemon fatal error: API key not configured")
+  })
+
+  test("returns last ~2KB for large log", async () => {
+    const runDir = join(tmpDir, "large-log")
+    await mkdir(runDir, { recursive: true })
+    // Write 5KB of padding + a distinctive error at the end
+    const padding = "x".repeat(4096) + "\n"
+    const errorLine = "Daemon fatal error: something broke badly\n"
+    await Bun.write(join(runDir, "daemon.log"), padding + errorLine)
+    const result = await readDaemonLogTail(runDir)
+    expect(result).toContain("Daemon fatal error: something broke badly")
+    // Should NOT contain the full padding (only last ~2KB)
+    expect(result.length).toBeLessThan(3000)
+  })
+
+  test("preserves multiline error output", async () => {
+    const runDir = join(tmpDir, "multiline-log")
+    await mkdir(runDir, { recursive: true })
+    const content = [
+      "Starting experiment loop...",
+      "Error: ANTHROPIC_API_KEY is not set",
+      "  at validateConfig (/src/lib/config.ts:42:11)",
+      "  at main (/src/daemon.ts:69:3)",
+    ].join("\n")
+    await Bun.write(join(runDir, "daemon.log"), content + "\n")
+    const result = await readDaemonLogTail(runDir)
+    expect(result).toContain("ANTHROPIC_API_KEY is not set")
+    expect(result).toContain("at validateConfig")
+  })
+})
+
+// --- Integration: spawn a real daemon that fails ---
+
+describe("daemon startup failure", () => {
+  test("records baseline failure in state.json with descriptive error", async () => {
+    // When measure.sh fails, the daemon handles it gracefully:
+    // writes error to state.json and exits cleanly.
+    const cwd = await mkdtemp(join(tmpdir(), "daemon-fail-measure-"))
+    try {
+      await $`git init`.cwd(cwd).quiet()
+      await $`git config user.email "test@test.com"`.cwd(cwd).quiet()
+      await $`git config user.name "Test User"`.cwd(cwd).quiet()
+
+      const programSlug = "bad-measure"
+      const programDir = join(cwd, ".autoauto", "programs", programSlug)
+      await mkdir(programDir, { recursive: true })
+
+      await Bun.write(
+        join(cwd, ".autoauto", "config.json"),
+        JSON.stringify({
+          executionModel: { provider: "claude", model: "sonnet", effort: "high" },
+          supportModel: { provider: "claude", model: "haiku", effort: "low" },
+        }),
+      )
+
+      // Measure script that exits non-zero
+      await Bun.write(join(programDir, "measure.sh"), "#!/bin/bash\necho 'THIS IS NOT JSON'\nexit 1\n")
+      await chmod(join(programDir, "measure.sh"), 0o755)
+
+      await Bun.write(
+        join(programDir, "config.json"),
+        JSON.stringify({
+          metric_field: "score",
+          direction: "lower",
+          noise_threshold: 0.02,
+          repeats: 1,
+          max_experiments: 10,
+          quality_gates: {},
+        }),
+      )
+
+      await Bun.write(join(cwd, "README.md"), "# test\n")
+      await $`git add -A`.cwd(cwd).quiet()
+      await $`git commit -m "init"`.cwd(cwd).quiet()
+
+      const modelConfig = { provider: "claude" as const, model: "sonnet", effort: "high" as const }
+      const result = await spawnDaemon(cwd, programSlug, modelConfig, 5, true, false)
+
+      // Wait for daemon process to exit
+      const exited = await waitForProcessExit(result.pid, 15_000)
+      expect(exited).toBe(true)
+
+      // State should reflect baseline failure with descriptive error
+      const state = await Bun.file(join(result.runDir, "state.json")).json() as { phase: string; error: string | null; error_phase: string | null }
+      expect(state.phase).toBe("crashed")
+      expect(state.error).toContain("Baseline measurement failed")
+      expect(state.error_phase).toBe("baseline")
+
+      await releaseLock(programDir)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  }, 20_000)
+
+  test("getDaemonStatus detects death via PID even with fresh heartbeat", async () => {
+    // Simulates a daemon that wrote a heartbeat then crashed immediately.
+    // getDaemonStatus should detect the dead PID rather than trusting the fresh heartbeat.
+    const cwd = await mkdtemp(join(tmpdir(), "daemon-fail-pidcheck-"))
+    try {
+      await $`git init`.cwd(cwd).quiet()
+      await $`git config user.email "test@test.com"`.cwd(cwd).quiet()
+      await $`git config user.name "Test User"`.cwd(cwd).quiet()
+
+      const programSlug = "pid-check"
+      const programDir = join(cwd, ".autoauto", "programs", programSlug)
+      await mkdir(programDir, { recursive: true })
+      await Bun.write(join(cwd, ".autoauto", "config.json"), JSON.stringify({
+        executionModel: { provider: "claude", model: "sonnet", effort: "high" },
+        supportModel: { provider: "claude", model: "haiku", effort: "low" },
+      }))
+      // Invalid config to make daemon crash on startup
+      await Bun.write(join(programDir, "config.json"), JSON.stringify({ bad: true }))
+      await Bun.write(join(cwd, "README.md"), "# test\n")
+      await $`git add -A`.cwd(cwd).quiet()
+      await $`git commit -m "init"`.cwd(cwd).quiet()
+
+      const modelConfig = { provider: "claude" as const, model: "sonnet", effort: "high" as const }
+      const result = await spawnDaemon(cwd, programSlug, modelConfig, 5, true, false)
+
+      // Wait for daemon to exit
+      const exited = await waitForProcessExit(result.pid, 10_000)
+      expect(exited).toBe(true)
+
+      // daemon.json has a fresh heartbeat_at (written during startup), but PID is dead.
+      // getDaemonStatus should report alive=false immediately, not wait 30s.
+      const status = await getDaemonStatus(result.runDir)
+      expect(status.alive).toBe(false)
+
+      await releaseLock(programDir)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  }, 15_000)
+
+  test("writes error to daemon.log when program config is missing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "daemon-fail-noconfig-"))
+    try {
+      await $`git init`.cwd(cwd).quiet()
+      await $`git config user.email "test@test.com"`.cwd(cwd).quiet()
+      await $`git config user.name "Test User"`.cwd(cwd).quiet()
+
+      const programSlug = "no-config"
+      const programDir = join(cwd, ".autoauto", "programs", programSlug)
+      await mkdir(join(programDir, "runs"), { recursive: true })
+
+      await Bun.write(
+        join(cwd, ".autoauto", "config.json"),
+        JSON.stringify({
+          executionModel: { provider: "claude", model: "sonnet", effort: "high" },
+          supportModel: { provider: "claude", model: "haiku", effort: "low" },
+        }),
+      )
+
+      await Bun.write(join(cwd, "README.md"), "# test\n")
+      await $`git add -A`.cwd(cwd).quiet()
+      await $`git commit -m "init"`.cwd(cwd).quiet()
+
+      const modelConfig = { provider: "claude" as const, model: "sonnet", effort: "high" as const }
+      const result = await spawnDaemon(cwd, programSlug, modelConfig, 5, true, false)
+
+      const exited = await waitForProcessExit(result.pid, 15_000)
+      expect(exited).toBe(true)
+
+      // daemon.log should contain something about the missing config
+      const logTail = await readDaemonLogTail(result.runDir)
+      expect(logTail.length).toBeGreaterThan(0)
+      // The daemon writes "Daemon fatal error: ..." for unhandled exceptions
+      expect(logTail).toContain("Daemon fatal error")
+
+      await releaseLock(programDir)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  }, 20_000)
+})

--- a/src/lib/daemon-error.test.ts
+++ b/src/lib/daemon-error.test.ts
@@ -142,8 +142,8 @@ describe("daemon startup failure", () => {
       expect(state.error).toContain("Baseline measurement failed")
       expect(state.error_phase).toBe("baseline")
 
-      await releaseLock(programDir)
     } finally {
+      await releaseLock(programDir).catch(() => {})
       await rm(cwd, { recursive: true, force: true })
     }
   }, 20_000)
@@ -182,8 +182,8 @@ describe("daemon startup failure", () => {
       const status = await getDaemonStatus(result.runDir)
       expect(status.alive).toBe(false)
 
-      await releaseLock(programDir)
     } finally {
+      await releaseLock(programDir).catch(() => {})
       await rm(cwd, { recursive: true, force: true })
     }
   }, 15_000)
@@ -223,8 +223,8 @@ describe("daemon startup failure", () => {
       // The daemon writes "Daemon fatal error: ..." for unhandled exceptions
       expect(logTail).toContain("Daemon fatal error")
 
-      await releaseLock(programDir)
     } finally {
+      await releaseLock(programDir).catch(() => {})
       await rm(cwd, { recursive: true, force: true })
     }
   }, 20_000)

--- a/src/lib/daemon-error.test.ts
+++ b/src/lib/daemon-error.test.ts
@@ -92,13 +92,12 @@ describe("daemon startup failure", () => {
     // When measure.sh fails, the daemon handles it gracefully:
     // writes error to state.json and exits cleanly.
     const cwd = await mkdtemp(join(tmpdir(), "daemon-fail-measure-"))
+    const programSlug = "bad-measure"
+    const programDir = join(cwd, ".autoauto", "programs", programSlug)
     try {
       await $`git init`.cwd(cwd).quiet()
       await $`git config user.email "test@test.com"`.cwd(cwd).quiet()
       await $`git config user.name "Test User"`.cwd(cwd).quiet()
-
-      const programSlug = "bad-measure"
-      const programDir = join(cwd, ".autoauto", "programs", programSlug)
       await mkdir(programDir, { recursive: true })
 
       await Bun.write(
@@ -152,13 +151,12 @@ describe("daemon startup failure", () => {
     // Simulates a daemon that wrote a heartbeat then crashed immediately.
     // getDaemonStatus should detect the dead PID rather than trusting the fresh heartbeat.
     const cwd = await mkdtemp(join(tmpdir(), "daemon-fail-pidcheck-"))
+    const programSlug = "pid-check"
+    const programDir = join(cwd, ".autoauto", "programs", programSlug)
     try {
       await $`git init`.cwd(cwd).quiet()
       await $`git config user.email "test@test.com"`.cwd(cwd).quiet()
       await $`git config user.name "Test User"`.cwd(cwd).quiet()
-
-      const programSlug = "pid-check"
-      const programDir = join(cwd, ".autoauto", "programs", programSlug)
       await mkdir(programDir, { recursive: true })
       await Bun.write(join(cwd, ".autoauto", "config.json"), JSON.stringify({
         executionModel: { provider: "claude", model: "sonnet", effort: "high" },
@@ -190,13 +188,12 @@ describe("daemon startup failure", () => {
 
   test("writes error to daemon.log when program config is missing", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "daemon-fail-noconfig-"))
+    const programSlug = "no-config"
+    const programDir = join(cwd, ".autoauto", "programs", programSlug)
     try {
       await $`git init`.cwd(cwd).quiet()
       await $`git config user.email "test@test.com"`.cwd(cwd).quiet()
       await $`git config user.name "Test User"`.cwd(cwd).quiet()
-
-      const programSlug = "no-config"
-      const programDir = join(cwd, ".autoauto", "programs", programSlug)
       await mkdir(join(programDir, "runs"), { recursive: true })
 
       await Bun.write(

--- a/src/lib/daemon-status.ts
+++ b/src/lib/daemon-status.ts
@@ -58,6 +58,14 @@ export async function getDaemonStatus(runDir: string): Promise<DaemonStatus> {
     }
   }
 
+  // Heartbeat is fresh, but verify the process is actually alive.
+  // The daemon may have crashed right after writing a heartbeat.
+  try {
+    process.kill(daemon.pid, 0)
+  } catch {
+    return { alive: false, starting: false, daemonJson: daemon }
+  }
+
   return { alive: true, starting: false, daemonJson: daemon }
 }
 
@@ -185,6 +193,26 @@ export async function updateMaxCostUsd(runDir: string, maxCostUsd: number | unde
 export async function getMaxCostUsd(runDir: string): Promise<number | undefined> {
   const config = await readRunConfig(runDir)
   return config?.max_cost_usd
+}
+
+// --- Daemon Log ---
+
+/**
+ * Read the last ~2KB of daemon.log for error context when daemon dies.
+ * Returns empty string if the log doesn't exist or is empty.
+ */
+export async function readDaemonLogTail(runDir: string): Promise<string> {
+  try {
+    const file = Bun.file(join(runDir, "daemon.log"))
+    const size = file.size
+    if (size === 0) return ""
+    const tail = size > 2048
+      ? await file.slice(size - 2048, size).text()
+      : await file.text()
+    return tail.trim()
+  } catch {
+    return ""
+  }
 }
 
 // --- Active Run Detection ---

--- a/src/lib/daemon-watcher.ts
+++ b/src/lib/daemon-watcher.ts
@@ -154,6 +154,9 @@ export function watchRunDir(
     scheduleRead(currentStreamFile)
   }, 250)
 
+  // Guard against duplicate onDaemonDied calls from overlapping timers
+  let daemonDiedFired = false
+
   // Early startup check — poll quickly for the first few seconds to catch
   // daemons that crash immediately (e.g. bad config). After 5s, fall back to
   // the slower 7s heartbeat interval.
@@ -166,7 +169,8 @@ export function watchRunDir(
       return
     }
     const status = await getDaemonStatus(runDir)
-    if (!status.alive && !status.starting) {
+    if (!status.alive && !status.starting && !stopped && !daemonDiedFired) {
+      daemonDiedFired = true
       callbacks.onDaemonDied()
       clearInterval(earlyCheckTimer)
     }
@@ -176,7 +180,8 @@ export function watchRunDir(
   const heartbeatTimer = setInterval(async () => {
     if (stopped) return
     const status = await getDaemonStatus(runDir)
-    if (!status.alive && !status.starting) {
+    if (!status.alive && !status.starting && !daemonDiedFired) {
+      daemonDiedFired = true
       callbacks.onDaemonDied()
     }
   }, 7_000)

--- a/src/lib/daemon-watcher.ts
+++ b/src/lib/daemon-watcher.ts
@@ -154,7 +154,25 @@ export function watchRunDir(
     scheduleRead(currentStreamFile)
   }, 250)
 
-  // Backup heartbeat timer (5-10s)
+  // Early startup check — poll quickly for the first few seconds to catch
+  // daemons that crash immediately (e.g. bad config). After 5s, fall back to
+  // the slower 7s heartbeat interval.
+  let earlyCheckCount = 0
+  const earlyCheckTimer = setInterval(async () => {
+    if (stopped) return
+    earlyCheckCount++
+    if (earlyCheckCount > 5) {
+      clearInterval(earlyCheckTimer)
+      return
+    }
+    const status = await getDaemonStatus(runDir)
+    if (!status.alive && !status.starting) {
+      callbacks.onDaemonDied()
+      clearInterval(earlyCheckTimer)
+    }
+  }, 1_000)
+
+  // Backup heartbeat timer (7s)
   const heartbeatTimer = setInterval(async () => {
     if (stopped) return
     const status = await getDaemonStatus(runDir)
@@ -184,6 +202,7 @@ export function watchRunDir(
       stopped = true
       watcher?.close()
       clearInterval(streamPollTimer)
+      clearInterval(earlyCheckTimer)
       clearInterval(heartbeatTimer)
       if (pollTimer) clearInterval(pollTimer)
       if (flushTimer) clearTimeout(flushTimer)

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -28,6 +28,7 @@ import {
   getDaemonStatus,
   updateMaxExperiments,
   getMaxExperiments,
+  readDaemonLogTail,
   type DaemonWatcher,
 } from "../lib/daemon-client.ts"
 import { RunCompletePrompt } from "../components/RunCompletePrompt.tsx"
@@ -196,8 +197,11 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
           if (!status.alive) {
             // Daemon died — show complete state
             try {
-              const reconstructed = await reconstructState(activeRunDir, programDir)
-              const currentMax = await getMaxExperiments(activeRunDir)
+              const [reconstructed, currentMax, logTail] = await Promise.all([
+                reconstructState(activeRunDir, programDir),
+                getMaxExperiments(activeRunDir),
+                readDaemonLogTail(activeRunDir),
+              ])
               if (!cancelled) {
                 setRunDir(activeRunDir)
                 setRunState(reconstructed.state)
@@ -216,18 +220,20 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
                   maxExpTextRef.current = text
                 }
                 if (reconstructed.state.phase === "crashed") {
-                  setLastError(reconstructed.state.error ?? "Daemon crashed")
+                  setLastError(reconstructed.state.error ?? (logTail || "Daemon crashed"))
                   setPhase("error")
                 } else if (reconstructed.state.phase === "complete") {
                   setPhase("complete")
                 } else {
-                  setLastError(`Daemon is not running; last phase was ${reconstructed.state.phase}`)
+                  const detail = logTail ? `\n\n${logTail}` : ""
+                  setLastError(`Daemon is not running; last phase was ${reconstructed.state.phase}${detail}`)
                   setPhase("error")
                 }
               }
             } catch (err: unknown) {
               if (!cancelled) {
-                setLastError(formatShellError(err))
+                const logTail = await readDaemonLogTail(activeRunDir)
+                setLastError(logTail || formatShellError(err))
                 setPhase("error")
               }
             }
@@ -319,25 +325,29 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
             },
             onDaemonDied: () => {
               if (cancelled) return
-              // Re-read final state
-              reconstructState(activeRunDir, programDir).then((final) => {
+              // Re-read final state + daemon log for error context
+              Promise.all([
+                reconstructState(activeRunDir, programDir).catch(() => null),
+                readDaemonLogTail(activeRunDir),
+              ]).then(([final, logTail]) => {
                 if (cancelled) return
-                setRunState(final.state)
-                setResults(final.results)
-                setMetricHistory(final.metricHistory)
-                setTerminationReason(final.state.termination_reason ?? null)
-                if (final.state.phase === "crashed") {
-                  setLastError(final.state.error ?? "Daemon died unexpectedly")
-                  setPhase("error")
-                } else if (final.state.phase === "complete") {
-                  setPhase("complete")
+                if (final) {
+                  setRunState(final.state)
+                  setResults(final.results)
+                  setMetricHistory(final.metricHistory)
+                  setTerminationReason(final.state.termination_reason ?? null)
+                  if (final.state.phase === "crashed") {
+                    setLastError(final.state.error ?? (logTail || "Daemon died unexpectedly"))
+                    setPhase("error")
+                  } else if (final.state.phase === "complete") {
+                    setPhase("complete")
+                  } else {
+                    const detail = logTail ? `\n\n${logTail}` : ""
+                    setLastError(`Daemon died unexpectedly while ${final.state.phase}${detail}`)
+                    setPhase("error")
+                  }
                 } else {
-                  setLastError(`Daemon died unexpectedly while ${final.state.phase}`)
-                  setPhase("error")
-                }
-              }).catch(() => {
-                if (!cancelled) {
-                  setLastError("Daemon died and state could not be read")
+                  setLastError(logTail || "Daemon died and state could not be read")
                   setPhase("error")
                 }
               })


### PR DESCRIPTION
## Summary

- **Faster detection**: `getDaemonStatus` now verifies PID liveness even when heartbeat is fresh — crash detected in ~1s instead of ~30s
- **Early startup polling**: watcher polls every 1s for the first 5s to catch instant startup failures (e.g. invalid config)
- **Actual error shown**: on daemon death, reads the tail of `daemon.log` and shows it in the error screen instead of generic messages like "Daemon died and state could not be read"

## Test plan

- [x] `readDaemonLogTail` unit tests (missing file, empty, small, large truncation, multiline)
- [x] Integration test: spawn real daemon with failing measure script → state.json records baseline error
- [x] Integration test: spawn real daemon with missing program config → daemon.log captures fatal error
- [x] Integration test: `getDaemonStatus` detects dead PID even with fresh heartbeat
- [x] All 194 existing tests still pass
- [x] Lint + typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon log tail is now exposed and shown in error messages and final status screens to aid troubleshooting
  * Startup monitoring now polls more aggressively during early startup to detect failures sooner

* **Bug Fixes**
  * Stronger liveness verification for daemon processes to avoid false-alive reports
  * UI now prefers log-tail context when reporting attach/startup errors

* **Tests**
  * Added unit and integration tests covering log-tail behavior, startup failures, and crash handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->