### PR TITLE
feat: auto-fallback to alternate model on provider limits

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -270,6 +270,7 @@ export function App() {
             attachRunId={attachRunId ?? undefined}
             readOnly={attachReadOnly}
             autoFinalize={autoFinalize}
+            fallbackModel={projectConfig.executionFallbackModel}
             onUpdateProgram={(slug) => {
               setPreRunOverrides(null)
               setAttachRunId(null)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -388,7 +388,8 @@ async function cmdStart(args: ParsedArgs) {
   // Spawn daemon
   let result: { runId: string; runDir: string; worktreePath: string | null; pid: number }
   try {
-    result = await spawnDaemon(root, slug, modelConfig, maxExperiments, ideasBacklogEnabled, useWorktree, carryForward)
+    const projConfig = await loadProjectConfig(root)
+    result = await spawnDaemon(root, slug, modelConfig, maxExperiments, ideasBacklogEnabled, useWorktree, carryForward, "manual", undefined, undefined, projConfig.executionFallbackModel)
   } catch (err) {
     const msg = formatShellError(err)
     if (msg.includes("uncommitted changes")) die(msg)

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -170,6 +170,20 @@ async function main() {
       const baseline = await runMeasurementSeries(measureShPath, worktreePath, config, abortController.signal, buildShPath)
 
       if (!baseline.success) {
+        // If aborted by user, treat as a clean abort — not a crash
+        if (abortController.signal.aborted) {
+          const abortedState: RunState = {
+            ...baselineState,
+            phase: "complete",
+            termination_reason: "aborted",
+            updated_at: new Date().toISOString(),
+          }
+          await writeState(runDir, abortedState)
+          await unlockMeasurement(programDir)
+          await releaseLock(programDir)
+          return
+        }
+
         const errorState: RunState = {
           ...baselineState,
           phase: "crashed",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -25,7 +25,8 @@ import {
   writeDaemonJson,
   startHeartbeat,
   readRunConfig,
-  runConfigToModelSlot,
+  runConfigToFallbackSlot,
+  runConfigToActiveSlot,
   readControl,
   releaseLock,
   recoverFromCrash,
@@ -79,7 +80,8 @@ async function main() {
 
   // 2. Read per-run config
   const runConfig = await readRunConfig(runDir)
-  const modelConfig = runConfig ? runConfigToModelSlot(runConfig) : { provider: "claude" as const, model: "sonnet", effort: "high" as const }
+  const modelConfig = runConfig ? runConfigToActiveSlot(runConfig) : { provider: "claude" as const, model: "sonnet", effort: "high" as const }
+  const fallbackModel = runConfig ? runConfigToFallbackSlot(runConfig) : null
   if (!runConfig?.max_experiments) throw new Error("run-config.json must specify max_experiments")
   const maxExperiments = runConfig.max_experiments
   const maxCostUsd = runConfig?.max_cost_usd
@@ -252,6 +254,7 @@ async function main() {
           ideasBacklogEnabled,
           carryForward,
           baselineDiagnostics: baseline.diagnostics,
+          fallbackModel: fallbackModel ?? undefined,
         },
       )
     } else {
@@ -272,6 +275,7 @@ async function main() {
           stopRequested: () => stopRequested,
           ideasBacklogEnabled,
           carryForward,
+          fallbackModel: fallbackModel ?? undefined,
         },
       )
     }

--- a/src/e2e/queue.e2e.test.tsx
+++ b/src/e2e/queue.e2e.test.tsx
@@ -17,6 +17,7 @@ import {
   popQueue,
   readQueue,
   removeFromQueue,
+  startNextFromQueue,
   writeQueue,
   type NewQueueEntry,
 } from "../lib/queue.ts"
@@ -294,30 +295,20 @@ describe("queue — concurrent locking", () => {
 })
 
 describe("queue — startNextFromQueue", () => {
-  // Mock spawnDaemon so we don't spawn real processes
+  // Mock spawnDaemon so we don't spawn real processes — passed via spawnFn parameter
   const spawnDaemonMock = mock(() =>
     Promise.resolve({ runId: "mock-run-id", runDir: "/tmp/mock-run", worktreePath: null, pid: 12345 }),
-  )
+  ) as any
 
   beforeEach(async () => {
     await clearQueue(fixture.cwd)
     spawnDaemonMock.mockClear()
   })
 
-  afterEach(async () => {
-    mock.restore()
-  })
-
   test("starts daemon with correct config from queue entry", async () => {
-    mock.module("../lib/daemon-spawn.ts", () => ({
-      spawnDaemon: spawnDaemonMock,
-    }))
-    // Re-import to pick up the mock
-    const { startNextFromQueue: startNext } = await import("../lib/queue.ts")
-
     await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 15 }))
 
-    const result = await startNext(fixture.cwd, true)
+    const result = await startNextFromQueue(fixture.cwd, true, spawnDaemonMock)
     expect(result.started).toBe(true)
     if (result.started) {
       expect(result.entry.programSlug).toBe("bench")
@@ -339,22 +330,12 @@ describe("queue — startNextFromQueue", () => {
   })
 
   test("returns started=false when queue is empty", async () => {
-    mock.module("../lib/daemon-spawn.ts", () => ({
-      spawnDaemon: spawnDaemonMock,
-    }))
-    const { startNextFromQueue: startNext } = await import("../lib/queue.ts")
-
-    const result = await startNext(fixture.cwd, true)
+    const result = await startNextFromQueue(fixture.cwd, true, spawnDaemonMock)
     expect(result.started).toBe(false)
     expect(spawnDaemonMock).not.toHaveBeenCalled()
   })
 
   test("skips entries that exceeded MAX_RETRIES and processes next", async () => {
-    mock.module("../lib/daemon-spawn.ts", () => ({
-      spawnDaemon: spawnDaemonMock,
-    }))
-    const { startNextFromQueue: startNext, readQueue: readQ } = await import("../lib/queue.ts")
-
     // Write queue with a failed entry (retryCount >= 2) followed by a good one
     await writeQueue(fixture.cwd, {
       nextId: 3,
@@ -382,7 +363,7 @@ describe("queue — startNextFromQueue", () => {
       ],
     })
 
-    const result = await startNext(fixture.cwd, true)
+    const result = await startNextFromQueue(fixture.cwd, true, spawnDaemonMock)
     expect(result.started).toBe(true)
     if (result.started) {
       expect(result.entry.id).toBe(2)
@@ -390,16 +371,12 @@ describe("queue — startNextFromQueue", () => {
     }
 
     // Failed entry should be discarded, good one started
-    const queue = await readQ(fixture.cwd)
+    const queue = await readQueue(fixture.cwd)
     expect(queue.entries).toHaveLength(0)
   })
 
   test("re-inserts entry with incremented retryCount on spawn failure", async () => {
-    const failingSpawn = mock(() => Promise.reject(new Error("spawn failed")))
-    mock.module("../lib/daemon-spawn.ts", () => ({
-      spawnDaemon: failingSpawn,
-    }))
-    const { startNextFromQueue: startNext } = await import("../lib/queue.ts")
+    const failingSpawn = mock(() => Promise.reject(new Error("spawn failed"))) as any
 
     // Add two entries — first will fail to spawn, second should be tried next
     await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 10 }))
@@ -412,7 +389,7 @@ describe("queue — startNextFromQueue", () => {
     // then pops first again (retryCount=2) → skipped,
     // then pops second again (retryCount=2) → skipped,
     // queue empty → returns started=false
-    const result = await startNext(fixture.cwd, true)
+    const result = await startNextFromQueue(fixture.cwd, true, failingSpawn)
     expect(result.started).toBe(false)
     expect(result.lastError).toBeTruthy()
 
@@ -426,15 +403,11 @@ describe("queue — startNextFromQueue", () => {
     const trackingSpawn = mock((_root: string, slug: string) => {
       startedEntries.push(slug)
       return Promise.resolve({ runId: `run-${slug}`, runDir: "/tmp/mock", worktreePath: null, pid: 1 })
-    })
-    mock.module("../lib/daemon-spawn.ts", () => ({
-      spawnDaemon: trackingSpawn,
-    }))
-    const { startNextFromQueue: startNext } = await import("../lib/queue.ts")
+    }) as any
 
     await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench" }))
 
-    const result = await startNext(fixture.cwd, true)
+    const result = await startNextFromQueue(fixture.cwd, true, trackingSpawn)
     expect(result.started).toBe(true)
     // startNextFromQueue starts one entry and returns — it doesn't drain the queue
     expect(startedEntries).toEqual(["bench"])

--- a/src/e2e/queue.e2e.test.tsx
+++ b/src/e2e/queue.e2e.test.tsx
@@ -1,0 +1,507 @@
+/**
+ * E2E tests for queue operations: append, pop, remove, clear, ordering,
+ * concurrent locking, program exclusivity, retry logic, and startNextFromQueue.
+ *
+ * These tests exercise the real queue functions against real filesystem state.
+ * Only spawnDaemon is mocked (it spawns actual processes), everything else
+ * runs against a real temp git repo via the standard test fixture.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { join } from "node:path"
+import { createTestFixture, registerMockProviders, type TestFixture } from "./fixture.ts"
+import { DEFAULT_CONFIG } from "../lib/config.ts"
+import {
+  appendToQueue,
+  clearQueue,
+  popQueue,
+  readQueue,
+  removeFromQueue,
+  writeQueue,
+  type NewQueueEntry,
+} from "../lib/queue.ts"
+import { acquireLock, releaseLock } from "../lib/daemon-lifecycle.ts"
+import { getProgramDir, resetProjectRoot } from "../lib/programs.ts"
+import { renderTui, noop, type TuiHarness } from "./helpers.ts"
+import { HomeScreen } from "../screens/HomeScreen.tsx"
+
+const MODEL = DEFAULT_CONFIG.executionModel
+
+function makeEntry(overrides: Partial<NewQueueEntry> = {}): NewQueueEntry {
+  return {
+    programSlug: "bench",
+    modelConfig: MODEL,
+    maxExperiments: 10,
+    useWorktree: true,
+    ...overrides,
+  }
+}
+
+let fixture: TestFixture
+
+beforeAll(async () => {
+  registerMockProviders()
+  fixture = await createTestFixture()
+  await fixture.createProgram("bench", {
+    metric_field: "latency_ms",
+    direction: "lower",
+    max_experiments: 10,
+  })
+  await fixture.createProgram("other", {
+    metric_field: "throughput",
+    direction: "higher",
+    max_experiments: 5,
+  })
+})
+
+afterAll(async () => {
+  await fixture.cleanup()
+})
+
+describe("queue — append and read", () => {
+  beforeEach(async () => {
+    await clearQueue(fixture.cwd)
+  })
+
+  test("appending to empty queue returns wasEmpty=true and assigns id=1", async () => {
+    const { entry, wasEmpty } = await appendToQueue(fixture.cwd, makeEntry())
+    expect(wasEmpty).toBe(true)
+    expect(entry.id).toBe(1)
+    expect(entry.programSlug).toBe("bench")
+    expect(entry.retryCount).toBe(0)
+    expect(entry.lastError).toBeNull()
+    expect(entry.addedAt).toBeTruthy()
+  })
+
+  test("appending second entry returns wasEmpty=false and auto-increments id", async () => {
+    const { entry: first } = await appendToQueue(fixture.cwd, makeEntry())
+    const { entry, wasEmpty } = await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 20 }))
+    expect(wasEmpty).toBe(false)
+    expect(entry.id).toBe(first.id + 1)
+    expect(entry.maxExperiments).toBe(20)
+  })
+
+  test("readQueue reflects all appended entries in order", async () => {
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench" }))
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "other" }))
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 30 }))
+
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(3)
+    expect(queue.entries[0].programSlug).toBe("bench")
+    expect(queue.entries[1].programSlug).toBe("other")
+    expect(queue.entries[2].maxExperiments).toBe(30)
+    // nextId should be one past the last assigned id
+    expect(queue.nextId).toBe(queue.entries[2].id + 1)
+  })
+
+  test("readQueue returns empty state for nonexistent queue file", async () => {
+    // clearQueue already ran, queue.json exists but is empty
+    const { unlink } = await import("node:fs/promises")
+    await unlink(join(fixture.cwd, ".autoauto", "queue.json")).catch(() => {})
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(0)
+    expect(queue.nextId).toBe(1)
+  })
+})
+
+describe("queue — pop", () => {
+  beforeEach(async () => {
+    await clearQueue(fixture.cwd)
+  })
+
+  test("popQueue returns first entry and removes it (FIFO)", async () => {
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 10 }))
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 20 }))
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 30 }))
+
+    const first = await popQueue(fixture.cwd)
+    expect(first).not.toBeNull()
+    expect(first!.maxExperiments).toBe(10)
+
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(2)
+    expect(queue.entries[0].maxExperiments).toBe(20)
+  })
+
+  test("popQueue returns null on empty queue", async () => {
+    const entry = await popQueue(fixture.cwd)
+    expect(entry).toBeNull()
+  })
+
+  test("successive pops drain the queue in FIFO order", async () => {
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 1 }))
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 2 }))
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 3 }))
+
+    const a = await popQueue(fixture.cwd)
+    const b = await popQueue(fixture.cwd)
+    const c = await popQueue(fixture.cwd)
+    const d = await popQueue(fixture.cwd)
+
+    expect(a!.maxExperiments).toBe(1)
+    expect(b!.maxExperiments).toBe(2)
+    expect(c!.maxExperiments).toBe(3)
+    expect(d).toBeNull()
+  })
+})
+
+describe("queue — remove by id", () => {
+  beforeEach(async () => {
+    await clearQueue(fixture.cwd)
+  })
+
+  test("removeFromQueue removes specific entry by id", async () => {
+    const { entry: e1 } = await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 10 }))
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 20 }))
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 30 }))
+
+    const removed = await removeFromQueue(fixture.cwd, e1.id)
+    expect(removed).not.toBeNull()
+    expect(removed!.maxExperiments).toBe(10)
+
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(2)
+    expect(queue.entries[0].maxExperiments).toBe(20)
+    expect(queue.entries[1].maxExperiments).toBe(30)
+  })
+
+  test("removeFromQueue returns null for nonexistent id", async () => {
+    await appendToQueue(fixture.cwd, makeEntry())
+    const removed = await removeFromQueue(fixture.cwd, 999)
+    expect(removed).toBeNull()
+  })
+
+  test("remove middle entry preserves order of remaining", async () => {
+    const { entry: e1 } = await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 10 }))
+    const { entry: e2 } = await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 20 }))
+    const { entry: e3 } = await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 30 }))
+
+    await removeFromQueue(fixture.cwd, e2.id)
+
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(2)
+    expect(queue.entries[0].id).toBe(e1.id)
+    expect(queue.entries[1].id).toBe(e3.id)
+  })
+})
+
+describe("queue — clear", () => {
+  beforeEach(async () => {
+    await clearQueue(fixture.cwd)
+  })
+
+  test("clearQueue empties queue and returns removed entries", async () => {
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 10 }))
+    await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: 20 }))
+
+    const cleared = await clearQueue(fixture.cwd)
+    expect(cleared).toHaveLength(2)
+    expect(cleared[0].maxExperiments).toBe(10)
+    expect(cleared[1].maxExperiments).toBe(20)
+
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(0)
+  })
+
+  test("clearQueue on empty queue returns empty array", async () => {
+    const cleared = await clearQueue(fixture.cwd)
+    expect(cleared).toHaveLength(0)
+  })
+})
+
+describe("queue — program exclusivity", () => {
+  beforeEach(async () => {
+    await clearQueue(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    // Release any locks we acquired
+    await releaseLock(getProgramDir(fixture.cwd, "bench"))
+    await releaseLock(getProgramDir(fixture.cwd, "other"))
+  })
+
+  test("rejects append when program has an active manual run (lock, no queue entries)", async () => {
+    const programDir = getProgramDir(fixture.cwd, "bench")
+    await acquireLock(programDir, "run-1", "daemon-1", 0, "/tmp/wt")
+
+    await expect(
+      appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench" })),
+    ).rejects.toThrow("active manual run")
+  })
+
+  test("allows append when program is locked but already has queue entries", async () => {
+    // First append succeeds (no lock)
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench" }))
+
+    // Acquire lock (simulating a running daemon started from queue)
+    const programDir = getProgramDir(fixture.cwd, "bench")
+    await acquireLock(programDir, "run-1", "daemon-1", 0, "/tmp/wt")
+
+    // Second append should succeed because queue entries already exist
+    const { entry } = await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 20 }))
+    expect(entry.maxExperiments).toBe(20)
+  })
+
+  test("allows append for different program even when another is locked", async () => {
+    const programDir = getProgramDir(fixture.cwd, "bench")
+    await acquireLock(programDir, "run-1", "daemon-1", 0, "/tmp/wt")
+
+    // Appending to "other" should succeed — exclusivity is per-program
+    const { entry } = await appendToQueue(fixture.cwd, makeEntry({ programSlug: "other" }))
+    expect(entry.programSlug).toBe("other")
+  })
+})
+
+describe("queue — concurrent locking", () => {
+  beforeEach(async () => {
+    await clearQueue(fixture.cwd)
+  })
+
+  test("concurrent appends all succeed with unique ids", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        appendToQueue(fixture.cwd, makeEntry({ maxExperiments: i + 1 })),
+      ),
+    )
+
+    const ids = results.map((r) => r.entry.id)
+    const uniqueIds = new Set(ids)
+    expect(uniqueIds.size).toBe(5)
+
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(5)
+  })
+
+  test("concurrent pops never return the same entry", async () => {
+    // Seed 5 entries
+    for (let i = 0; i < 5; i++) {
+      await appendToQueue(fixture.cwd, makeEntry({ maxExperiments: i + 1 }))
+    }
+
+    // Pop concurrently — some may return null if lock is contended
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => popQueue(fixture.cwd)),
+    )
+
+    const popped = results.filter((r) => r !== null)
+    const poppedIds = popped.map((r) => r!.id)
+    const uniquePoppedIds = new Set(poppedIds)
+
+    // All popped entries have unique ids (no double-pop)
+    expect(uniquePoppedIds.size).toBe(popped.length)
+  })
+})
+
+describe("queue — startNextFromQueue", () => {
+  // Mock spawnDaemon so we don't spawn real processes
+  const spawnDaemonMock = mock(() =>
+    Promise.resolve({ runId: "mock-run-id", runDir: "/tmp/mock-run", worktreePath: null, pid: 12345 }),
+  )
+
+  beforeEach(async () => {
+    await clearQueue(fixture.cwd)
+    spawnDaemonMock.mockClear()
+  })
+
+  afterEach(async () => {
+    mock.restore()
+  })
+
+  test("starts daemon with correct config from queue entry", async () => {
+    mock.module("../lib/daemon-spawn.ts", () => ({
+      spawnDaemon: spawnDaemonMock,
+    }))
+    // Re-import to pick up the mock
+    const { startNextFromQueue: startNext } = await import("../lib/queue.ts")
+
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 15 }))
+
+    const result = await startNext(fixture.cwd, true)
+    expect(result.started).toBe(true)
+    if (result.started) {
+      expect(result.entry.programSlug).toBe("bench")
+      expect(result.entry.maxExperiments).toBe(15)
+      expect(result.runId).toBe("mock-run-id")
+    }
+
+    // Verify spawnDaemon was called with correct args
+    expect(spawnDaemonMock).toHaveBeenCalledTimes(1)
+    const args = spawnDaemonMock.mock.calls[0]
+    expect(args[0]).toBe(fixture.cwd) // mainRoot
+    expect(args[1]).toBe("bench") // programSlug
+    expect(args[3]).toBe(15) // maxExperiments
+    expect(args[7]).toBe("queue") // source
+
+    // Queue should be empty after pop
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(0)
+  })
+
+  test("returns started=false when queue is empty", async () => {
+    mock.module("../lib/daemon-spawn.ts", () => ({
+      spawnDaemon: spawnDaemonMock,
+    }))
+    const { startNextFromQueue: startNext } = await import("../lib/queue.ts")
+
+    const result = await startNext(fixture.cwd, true)
+    expect(result.started).toBe(false)
+    expect(spawnDaemonMock).not.toHaveBeenCalled()
+  })
+
+  test("skips entries that exceeded MAX_RETRIES and processes next", async () => {
+    mock.module("../lib/daemon-spawn.ts", () => ({
+      spawnDaemon: spawnDaemonMock,
+    }))
+    const { startNextFromQueue: startNext, readQueue: readQ } = await import("../lib/queue.ts")
+
+    // Write queue with a failed entry (retryCount >= 2) followed by a good one
+    await writeQueue(fixture.cwd, {
+      nextId: 3,
+      entries: [
+        {
+          id: 1,
+          programSlug: "bench",
+          modelConfig: MODEL,
+          maxExperiments: 10,
+          useWorktree: true,
+          addedAt: new Date().toISOString(),
+          retryCount: 2, // exceeded MAX_RETRIES
+          lastError: "previous failure",
+        },
+        {
+          id: 2,
+          programSlug: "bench",
+          modelConfig: MODEL,
+          maxExperiments: 20,
+          useWorktree: true,
+          addedAt: new Date().toISOString(),
+          retryCount: 0,
+          lastError: null,
+        },
+      ],
+    })
+
+    const result = await startNext(fixture.cwd, true)
+    expect(result.started).toBe(true)
+    if (result.started) {
+      expect(result.entry.id).toBe(2)
+      expect(result.entry.maxExperiments).toBe(20)
+    }
+
+    // Failed entry should be discarded, good one started
+    const queue = await readQ(fixture.cwd)
+    expect(queue.entries).toHaveLength(0)
+  })
+
+  test("re-inserts entry with incremented retryCount on spawn failure", async () => {
+    const failingSpawn = mock(() => Promise.reject(new Error("spawn failed")))
+    mock.module("../lib/daemon-spawn.ts", () => ({
+      spawnDaemon: failingSpawn,
+    }))
+    const { startNextFromQueue: startNext } = await import("../lib/queue.ts")
+
+    // Add two entries — first will fail to spawn, second should be tried next
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 10 }))
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 20 }))
+
+    // startNextFromQueue loops: first entry fails → re-inserted with retryCount=1,
+    // then pops second entry → also fails → re-inserted with retryCount=1,
+    // then pops first again (retryCount=1) → fails → re-inserted with retryCount=2,
+    // then pops second again (retryCount=1) → fails → re-inserted with retryCount=2,
+    // then pops first again (retryCount=2) → skipped,
+    // then pops second again (retryCount=2) → skipped,
+    // queue empty → returns started=false
+    const result = await startNext(fixture.cwd, true)
+    expect(result.started).toBe(false)
+    expect(result.lastError).toBeTruthy()
+
+    // Both entries should have been exhausted
+    const queue = await readQueue(fixture.cwd)
+    expect(queue.entries).toHaveLength(0)
+  })
+
+  test("processes multiple entries in FIFO order", async () => {
+    const startedEntries: string[] = []
+    const trackingSpawn = mock((_root: string, slug: string) => {
+      startedEntries.push(slug)
+      return Promise.resolve({ runId: `run-${slug}`, runDir: "/tmp/mock", worktreePath: null, pid: 1 })
+    })
+    mock.module("../lib/daemon-spawn.ts", () => ({
+      spawnDaemon: trackingSpawn,
+    }))
+    const { startNextFromQueue: startNext } = await import("../lib/queue.ts")
+
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench" }))
+
+    const result = await startNext(fixture.cwd, true)
+    expect(result.started).toBe(true)
+    // startNextFromQueue starts one entry and returns — it doesn't drain the queue
+    expect(startedEntries).toEqual(["bench"])
+  })
+})
+
+describe("queue — UI display via HomeScreen", () => {
+  let harness: TuiHarness | null = null
+
+  beforeEach(async () => {
+    await clearQueue(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await harness?.destroy()
+    harness = null
+    resetProjectRoot()
+  })
+
+  function renderHome() {
+    return renderTui(
+      <HomeScreen
+        cwd={fixture.cwd}
+        navigate={noop}
+        onSelectProgram={noop}
+        onSelectRun={noop}
+        onUpdateProgram={noop}
+        onFinalizeRun={noop}
+        onResumeDraft={noop}
+      />,
+      { width: 120 },
+    )
+  }
+
+  test("adding entries via appendToQueue shows in HomeScreen", async () => {
+    // Add entries via real queue API
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 10 }))
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench", maxExperiments: 20 }))
+
+    harness = await renderHome()
+    const frame = await harness.waitForText("Queue (2)")
+    expect(frame).toContain("bench")
+  })
+
+  test("queue panel disappears after clearing all entries", async () => {
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench" }))
+
+    harness = await renderHome()
+    await harness.waitForText("Queue (1)")
+
+    // Clear queue via real API
+    await clearQueue(fixture.cwd)
+
+    // Re-render — panel should vanish. HomeScreen re-reads on focus.
+    await harness.destroy()
+    harness = await renderHome()
+    const frame = await harness.flush(200)
+    expect(frame).not.toContain("Queue (")
+  })
+
+  test("queue shows multiple programs", async () => {
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "bench" }))
+    await appendToQueue(fixture.cwd, makeEntry({ programSlug: "other" }))
+
+    harness = await renderHome()
+    const frame = await harness.waitForText("Queue (2)")
+    expect(frame).toContain("bench")
+    expect(frame).toContain("other")
+  })
+})

--- a/src/e2e/settings-screen.e2e.test.tsx
+++ b/src/e2e/settings-screen.e2e.test.tsx
@@ -70,7 +70,8 @@ describe("SettingsScreen E2E", () => {
   test("toggles ideas backlog", async () => {
     harness = await renderTui(<SettingsWrapper cwd={fixture.cwd} />)
     await harness.frame()
-    for (let i = 0; i < 6; i++) await harness.press("j")
+    // Row 7: ideas backlog (0-2: exec, 3-5: support, 6: fallback toggle, 7: ideas)
+    for (let i = 0; i < 7; i++) await harness.press("j")
     let frame = await harness.frame()
     expect(frame).toContain("Ideas Backlog")
     expect(frame).toContain("On")
@@ -92,7 +93,8 @@ describe("SettingsScreen E2E", () => {
   test("cycles notification preset and shows test row", async () => {
     harness = await renderTui(<SettingsWrapper cwd={fixture.cwd} />)
     await harness.frame()
-    for (let i = 0; i < 7; i++) await harness.press("j")
+    // Row 8: notification preset (0-2: exec, 3-5: support, 6: fallback toggle, 7: ideas, 8: preset)
+    for (let i = 0; i < 8; i++) await harness.press("j")
     await harness.press("l")
     const frame = await harness.flush()
     expect(frame).toContain("macOS Notification")

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -44,6 +44,8 @@ export const NOTIFICATION_PRESET_IDS = NOTIFICATION_PRESETS.map((p) => p.id)
 export interface ProjectConfig {
   executionModel: ModelSlot
   supportModel: ModelSlot
+  /** Optional fallback model when the execution model hits quota or persistent rate limits. */
+  executionFallbackModel?: ModelSlot | null
   ideasBacklogEnabled: boolean
   notificationPreset: NotificationPreset
   notificationCommand: string | null // only used when preset is "custom"
@@ -169,12 +171,13 @@ export async function loadProjectConfig(cwd: string): Promise<ProjectConfig> {
   const configPath = join(root, AUTOAUTO_DIR, CONFIG_FILE)
   try {
     const parsed = await Bun.file(configPath).json() as Record<string, unknown>
-    const { executionModel, supportModel, ...rest } = parsed as Partial<ProjectConfig>
+    const { executionModel, supportModel, executionFallbackModel, ...rest } = parsed as Partial<ProjectConfig>
     return {
       ...DEFAULT_CONFIG,
       ...rest,
       executionModel: normalizeModelSlot(executionModel),
       supportModel: normalizeModelSlot(supportModel),
+      executionFallbackModel: executionFallbackModel ? normalizeModelSlot(executionFallbackModel) : executionFallbackModel,
     }
   } catch {
     return { ...DEFAULT_CONFIG }

--- a/src/lib/daemon-lifecycle.ts
+++ b/src/lib/daemon-lifecycle.ts
@@ -29,6 +29,14 @@ export interface RunConfig {
   carry_forward?: boolean
   keep_simplifications?: boolean
   source?: "manual" | "queue"
+  /** Fallback model — used when the primary hits quota or persistent rate limits. */
+  fallback_provider?: AgentProviderID
+  fallback_model?: string
+  fallback_effort?: string
+  /** Active model override — set when fallback activates, survives daemon restart. */
+  active_provider?: AgentProviderID
+  active_model?: string
+  active_effort?: string
 }
 
 export interface ControlAction {
@@ -130,6 +138,27 @@ export function runConfigToModelSlot(config: RunConfig): ModelSlot {
     model: config.model,
     effort: config.effort as ModelSlot["effort"],
   }
+}
+
+/** Constructs a ModelSlot from individual fields, or null if any are missing. */
+function slotFromFields(provider?: AgentProviderID, model?: string, effort?: string): ModelSlot | null {
+  if (!provider || !model || !effort) return null
+  return { provider, model, effort: effort as ModelSlot["effort"] }
+}
+
+/** Returns the fallback model slot if configured, or null. */
+export function runConfigToFallbackSlot(config: RunConfig): ModelSlot | null {
+  return slotFromFields(config.fallback_provider, config.fallback_model, config.fallback_effort)
+}
+
+/** Returns the active model (fallback override if set, else primary). */
+export function runConfigToActiveSlot(config: RunConfig): ModelSlot {
+  return slotFromFields(config.active_provider, config.active_model, config.active_effort) ?? runConfigToModelSlot(config)
+}
+
+/** Returns a RunConfig with active model fields set to the given slot. */
+export function setActiveModelInRunConfig(config: RunConfig, model: ModelSlot): RunConfig {
+  return { ...config, active_provider: model.provider, active_model: model.model, active_effort: model.effort }
 }
 
 // --- Locking ---

--- a/src/lib/daemon-spawn.ts
+++ b/src/lib/daemon-spawn.ts
@@ -76,6 +76,12 @@ export async function spawnDaemon(
 
     // 3. Init run dir in main root + write run-config.json
     const runDir = await initRunDir(programDir, runId)
+    // Drop fallback if identical to primary — it would be a no-op
+    const distinctFallback = fallbackModel &&
+      (fallbackModel.provider !== modelConfig.provider ||
+       fallbackModel.model !== modelConfig.model ||
+       fallbackModel.effort !== modelConfig.effort)
+      ? fallbackModel : undefined
     const runConfig: RunConfig = {
       provider: modelConfig.provider,
       model: modelConfig.model,
@@ -87,9 +93,9 @@ export async function spawnDaemon(
       carry_forward: carryForward,
       keep_simplifications: keepSimplifications,
       source,
-      fallback_provider: fallbackModel?.provider,
-      fallback_model: fallbackModel?.model,
-      fallback_effort: fallbackModel?.effort,
+      fallback_provider: distinctFallback?.provider,
+      fallback_model: distinctFallback?.model,
+      fallback_effort: distinctFallback?.effort,
     }
     await writeRunConfig(runDir, runConfig)
 

--- a/src/lib/daemon-spawn.ts
+++ b/src/lib/daemon-spawn.ts
@@ -42,6 +42,7 @@ export async function spawnDaemon(
   source: "manual" | "queue" = "manual",
   maxCostUsd?: number,
   keepSimplifications?: boolean,
+  fallbackModel?: ModelSlot | null,
 ): Promise<{ runId: string; runDir: string; worktreePath: string | null; pid: number }> {
   // 1. Check working tree
   if (!(await isWorkingTreeClean(mainRoot))) {
@@ -86,6 +87,9 @@ export async function spawnDaemon(
       carry_forward: carryForward,
       keep_simplifications: keepSimplifications,
       source,
+      fallback_provider: fallbackModel?.provider,
+      fallback_model: fallbackModel?.model,
+      fallback_effort: fallbackModel?.effort,
     }
     await writeRunConfig(runDir, runConfig)
 

--- a/src/lib/experiment-loop.ts
+++ b/src/lib/experiment-loop.ts
@@ -2,7 +2,7 @@ import { chmod } from "node:fs/promises"
 import { join, relative } from "node:path"
 import type { RunState, ExperimentResult, TerminationReason, PreviousRunContext } from "./run.ts"
 import type { ProgramConfig } from "./programs.ts"
-import type { ModelSlot } from "./config.ts"
+import { type ModelSlot, formatModelLabel } from "./config.ts"
 import {
   readState,
   writeState,
@@ -31,7 +31,7 @@ import {
   type ExperimentCost,
 } from "./experiment.ts"
 import { appendIdeasBacklog, type ExperimentNotes } from "./ideas-backlog.ts"
-import { readRunConfig } from "./daemon-lifecycle.ts"
+import { readRunConfig, writeRunConfig, setActiveModelInRunConfig } from "./daemon-lifecycle.ts"
 import { getExperimentSystemPrompt } from "./system-prompts/index.ts"
 
 /** Re-measure baseline after this many consecutive discards to check for environment drift. */
@@ -74,6 +74,8 @@ export interface LoopOptions {
   baselineDiagnostics?: string
   /** Maximum cost in USD before stopping the run. Checked at iteration boundary. */
   maxCostUsd?: number
+  /** Fallback model — auto-switch when primary hits quota or persistent rate limits. */
+  fallbackModel?: ModelSlot
 }
 
 // --- Helpers ---
@@ -136,6 +138,23 @@ async function resetAndVerify(cwd: string, startSha: string, errorContext: strin
   if (!(await isWorkingTreeClean(cwd))) {
     throw new Error(`Working tree still dirty after ${errorContext}; stopping to avoid contaminating the next experiment.`)
   }
+}
+
+/** Persist the active model to run-config (daemon resume) and run state (TUI header). */
+async function persistModelSwitch(
+  model: ModelSlot,
+  runDir: string,
+  state: RunState,
+  runConfig: import("./daemon-lifecycle.ts").RunConfig | null,
+  callbacks: LoopCallbacks,
+): Promise<RunState> {
+  if (runConfig) {
+    await writeRunConfig(runDir, setActiveModelInRunConfig(runConfig, model))
+  }
+  const newState: RunState = { ...state, provider: model.provider, model: model.model, effort: model.effort }
+  await writeState(runDir, newState)
+  callbacks.onStateUpdate(newState)
+  return newState
 }
 
 async function recordIdeasBacklog(
@@ -430,6 +449,26 @@ export async function runExperimentLoop(
   const RAPID_FAILURE_WINDOW_MS = 30_000
   const RATE_LIMIT_PAUSE_MS = 60_000
 
+  // --- Fallback model state ---
+  let activeModel = modelConfig
+  let usingFallback = false
+  let consecutiveRateLimits = 0
+  const RATE_LIMIT_FALLBACK_THRESHOLD = 3
+  const fallbackSlot = options.fallbackModel ?? null
+
+  // Restore active model from run-config if daemon is resuming after a fallback switch
+  {
+    const initialRunConfig = await readRunConfig(runDir)
+    if (initialRunConfig?.active_provider && initialRunConfig.active_model && initialRunConfig.active_effort) {
+      activeModel = {
+        provider: initialRunConfig.active_provider,
+        model: initialRunConfig.active_model,
+        effort: initialRunConfig.active_effort as ModelSlot["effort"],
+      }
+      usingFallback = true
+    }
+  }
+
   // Re-read from run-config.json each iteration to support mid-run TUI changes
   let effectiveMaxExperiments = options.maxExperiments
   let effectiveMaxCostUsd = options.maxCostUsd
@@ -523,7 +562,7 @@ export async function runExperimentLoop(
       cwd,
       systemPrompt,
       userPrompt,
-      modelConfig,
+      activeModel,
       startSha,
       (text) => callbacks.onAgentStream(text),
       (status) => callbacks.onAgentToolUse(status),
@@ -573,53 +612,92 @@ export async function runExperimentLoop(
       break
     }
 
-    // --- Terminal error detection (quota exhausted or auth failure) → immediate stop ---
-    if (outcome.type === "agent_error" && (outcome.errorKind === "quota_exhausted" || outcome.errorKind === "auth_error")) {
+    // --- Auth error → always stop immediately (no fallback) ---
+    if (outcome.type === "agent_error" && outcome.errorKind === "auth_error") {
       const measurementViolations = await getMeasurementViolations(measurementSnapshot)
       if (measurementViolations.length > 0) await restoreMeasurementSnapshot(measurementSnapshot)
-      await resetAndVerify(cwd, startSha, `${outcome.errorKind} cleanup`)
+      await resetAndVerify(cwd, startSha, "auth_error cleanup")
 
-      const label = outcome.errorKind === "quota_exhausted" ? "quota exhausted" : "auth error"
-      const crashResult: ExperimentResult = {
-        experiment_number: experimentNumber,
-        commit: startSha.slice(0, 7),
-        metric_value: 0,
-        secondary_values: "",
-        status: "crash",
-        description: `${label}: ${outcome.error}`,
-        measurement_duration_ms: 0,
-      }
-      await appendResult(runDir, crashResult)
-      await recordIdeasBacklog(ideasBacklogEnabled, runDir, crashResult, outcome.notes)
-      callbacks.onExperimentEnd(crashResult)
-      callbacks.onError(`Provider ${label}: ${outcome.error}`)
-
+      // Auth errors are infrastructure failures, not experiment failures — no crash row.
+      // Roll back experiment number so the next attempt (if any) retries the same slot.
       state = {
         ...state,
-        total_crashes: state.total_crashes + 1,
+        experiment_number: state.experiment_number - 1,
         candidate_sha: null,
         phase: "stopping",
         updated_at: now(),
       }
       await writeState(runDir, state)
-      callbacks.onPhaseChange("stopping", `provider ${label}`)
+      callbacks.onError(`Provider auth error: ${outcome.error}`)
+      callbacks.onPhaseChange("stopping", "provider auth error")
       terminalError = true
       break
     }
 
-    // --- Rate limit → pause before retrying (fall through to normal error handling after) ---
+    // --- Quota exhausted → try fallback, else stop ---
+    if (outcome.type === "agent_error" && outcome.errorKind === "quota_exhausted") {
+      const measurementViolations = await getMeasurementViolations(measurementSnapshot)
+      if (measurementViolations.length > 0) await restoreMeasurementSnapshot(measurementSnapshot)
+      await resetAndVerify(cwd, startSha, "quota_exhausted cleanup")
+
+      // Roll back experiment number — infrastructure event, not an experiment
+      state = { ...state, experiment_number: state.experiment_number - 1, candidate_sha: null, updated_at: now() }
+
+      if (fallbackSlot && !usingFallback) {
+        activeModel = fallbackSlot
+        usingFallback = true
+        consecutiveRateLimits = 0
+        state = await persistModelSwitch(activeModel, runDir, state, runConfig, callbacks)
+        callbacks.onError(`Quota exhausted on ${formatModelLabel(modelConfig)} — switching to ${formatModelLabel(activeModel)}`)
+        callbacks.onPhaseChange("idle", `switched to fallback: ${formatModelLabel(activeModel)}`)
+        continue
+      }
+
+      // No fallback available or already on fallback — stop
+      state = { ...state, phase: "stopping" }
+      await writeState(runDir, state)
+      callbacks.onError(`Provider quota exhausted: ${outcome.error}`)
+      callbacks.onPhaseChange("stopping", "provider quota exhausted")
+      terminalError = true
+      break
+    }
+
+    // --- Rate limit → count consecutive hits, switch to fallback after threshold, else pause and retry ---
     if (outcome.type === "agent_error" && outcome.errorKind === "rate_limited") {
+      const measurementViolations = await getMeasurementViolations(measurementSnapshot)
+      if (measurementViolations.length > 0) await restoreMeasurementSnapshot(measurementSnapshot)
+      await resetAndVerify(cwd, startSha, "rate_limited cleanup")
+
+      // Roll back experiment number — infrastructure event, not an experiment
+      state = { ...state, experiment_number: state.experiment_number - 1, candidate_sha: null, updated_at: now() }
+      await writeState(runDir, state)
+
+      consecutiveRateLimits++
+
+      if (consecutiveRateLimits >= RATE_LIMIT_FALLBACK_THRESHOLD && fallbackSlot && !usingFallback) {
+        activeModel = fallbackSlot
+        usingFallback = true
+        consecutiveRateLimits = 0
+        state = await persistModelSwitch(activeModel, runDir, state, runConfig, callbacks)
+        callbacks.onError(`${RATE_LIMIT_FALLBACK_THRESHOLD} consecutive rate limits on ${formatModelLabel(modelConfig)} — switching to ${formatModelLabel(activeModel)}`)
+        callbacks.onPhaseChange("idle", `switched to fallback: ${formatModelLabel(activeModel)}`)
+        continue
+      }
+
+      // Pause and retry with same model
       const pauseSec = RATE_LIMIT_PAUSE_MS / 1000
-      callbacks.onError(`Rate limited by provider — pausing ${pauseSec}s before next experiment. Error: ${outcome.error}`)
+      callbacks.onError(`Rate limited by provider — pausing ${pauseSec}s before retry. Error: ${outcome.error}`)
       callbacks.onPhaseChange("idle", `rate limited — waiting ${pauseSec}s`)
       for (let i = 0; i < pauseSec; i++) {
         if (options.signal?.aborted) break
         await Bun.sleep(1000)
       }
+      continue
     }
 
-    // --- Rapid-failure backstop: catch unrecognized terminal errors ---
+    // --- Rapid-failure backstop: catch unrecognized terminal errors (generic only) ---
     if (outcome.type === "agent_error") {
+      consecutiveRateLimits = 0 // reset on non-rate-limit error
       const ts = Date.now()
       recentErrorTimestamps.push(ts)
       while (recentErrorTimestamps.length > 0 && ts - recentErrorTimestamps[0] > RAPID_FAILURE_WINDOW_MS) {
@@ -644,6 +722,7 @@ export async function runExperimentLoop(
         break
       }
     } else {
+      consecutiveRateLimits = 0
       recentErrorTimestamps.length = 0
     }
 

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -4,6 +4,7 @@ import type { ModelSlot } from "./config.ts"
 import { AUTOAUTO_DIR, getProgramDir } from "./programs.ts"
 import { readLock } from "./daemon-lifecycle.ts"
 import { spawnDaemon } from "./daemon-spawn.ts"
+import { loadProjectConfig } from "./config.ts"
 
 // --- Types ---
 
@@ -187,6 +188,7 @@ export async function startNextFromQueue(
   cwd: string,
   ideasBacklogEnabled: boolean,
 ): Promise<{ started: true; entry: QueueEntry; runId: string } | { started: false; lastError?: string }> {
+  const projConfig = await loadProjectConfig(cwd)
   let lastError: string | undefined
   while (true) {
     const entry = await popQueue(cwd)
@@ -209,6 +211,8 @@ export async function startNextFromQueue(
         true, // carryForward
         "queue",
         entry.maxCostUsd,
+        undefined, // keepSimplifications
+        projConfig.executionFallbackModel,
       )
       return { started: true, entry, runId }
     } catch (err) {

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -184,9 +184,12 @@ export function programHasQueueEntries(queue: QueueFile, programSlug: string): b
 /** Pop the next viable entry from the queue and spawn a daemon for it.
  *  Skips entries that have exceeded MAX_RETRIES.
  *  Returns lastError when entries were skipped/failed so callers can notify. */
+export type SpawnDaemonFn = typeof spawnDaemon
+
 export async function startNextFromQueue(
   cwd: string,
   ideasBacklogEnabled: boolean,
+  spawnFn: SpawnDaemonFn = spawnDaemon,
 ): Promise<{ started: true; entry: QueueEntry; runId: string } | { started: false; lastError?: string }> {
   const projConfig = await loadProjectConfig(cwd)
   let lastError: string | undefined
@@ -201,7 +204,7 @@ export async function startNextFromQueue(
     }
 
     try {
-      const { runId } = await spawnDaemon(
+      const { runId } = await spawnFn(
         cwd,
         entry.programSlug,
         entry.modelConfig,

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -75,6 +75,8 @@ interface ExecutionScreenProps {
   onUpdateProgram?: (programSlug: string) => void
   /** If true, automatically start finalize when the run is loaded as complete */
   autoFinalize?: boolean
+  /** Fallback model for auto-switching on quota/rate-limit exhaustion. */
+  fallbackModel?: ModelSlot | null
 }
 
 const PHASE_LABELS: Record<string, string> = {
@@ -119,7 +121,7 @@ function IdeasPanel({ text }: { text: string }) {
   )
 }
 
-export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelConfig, ideasBacklogEnabled, navigate, maxExperiments, maxCostUsd, useWorktree = true, carryForward = true, keepSimplifications, attachRunId, readOnly = false, autoFinalize = false, onUpdateProgram }: ExecutionScreenProps) {
+export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelConfig, ideasBacklogEnabled, navigate, maxExperiments, maxCostUsd, useWorktree = true, carryForward = true, keepSimplifications, attachRunId, readOnly = false, autoFinalize = false, onUpdateProgram, fallbackModel }: ExecutionScreenProps) {
   const { width: termWidth, height: termHeight } = useTerminalDimensions()
   const compact = termHeight < 30
   const [phase, setPhase] = useState<ExecutionPhase>("starting")
@@ -264,7 +266,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
           }
         } else {
           // Spawn mode: create worktree, spawn daemon
-          const result = await spawnDaemon(cwd, programSlug, modelConfig, maxExperiments, ideasBacklogEnabled, useWorktree, carryForward, "manual", maxCostUsd, keepSimplifications)
+          const result = await spawnDaemon(cwd, programSlug, modelConfig, maxExperiments, ideasBacklogEnabled, useWorktree, carryForward, "manual", maxCostUsd, keepSimplifications, fallbackModel)
           if (cancelled) return
 
           activeRunDir = result.runDir
@@ -374,7 +376,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
       cancelled = true
       watcherRef.current?.stop()
     }
-  }, [cwd, programSlug, modelConfig, maxExperiments, maxCostUsd, useWorktree, carryForward, keepSimplifications, attachRunId, ideasBacklogEnabled, retryCount])
+  }, [cwd, programSlug, modelConfig, maxExperiments, maxCostUsd, useWorktree, carryForward, keepSimplifications, attachRunId, ideasBacklogEnabled, retryCount, fallbackModel])
 
   const cleanupRunEnvironment = useCallback(async () => {
     if (runState?.in_place) {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -3,6 +3,7 @@ import { useKeyboard } from "@opentui/react"
 import type { Screen } from "../lib/programs.ts"
 import {
   type ProjectConfig,
+  type ModelSlot,
   cycleChoice,
   formatEffortSlot,
   formatModelSlot,
@@ -11,6 +12,7 @@ import {
   isEffortConfigurable,
   mergeSelectedModelSlot,
   saveProjectConfig,
+  DEFAULT_CONFIG,
   NOTIFICATION_PRESETS,
   NOTIFICATION_PRESET_IDS,
   PROVIDER_CHOICES,
@@ -32,10 +34,12 @@ interface SettingsScreenProps {
 // Row layout:
 // 0: exec provider   1: exec model   2: exec effort
 // 3: support provider 4: support model 5: support effort
-// 6: ideas backlog
-// 7: notification preset
-// 8: notification command (only when preset === "custom")
-// 9: test notification (only when preset !== "off")
+// 6: fallback enabled (toggle)
+// 7: fallback provider  8: fallback model  9: fallback effort  (only when fallback enabled)
+// N: ideas backlog
+// N+1: notification preset
+// N+2: notification command (only when preset === "custom")
+// N+3: test notification (only when preset !== "off")
 function makeTestState(): RunState {
   return {
     run_id: "20260408-120000",
@@ -61,22 +65,38 @@ function makeTestState(): RunState {
   }
 }
 
-function slotKeyForRow(row: number): "executionModel" | "supportModel" {
-  return row < 3 ? "executionModel" : "supportModel"
+function slotKeyForRow(row: number, fallbackEnabled: boolean): "executionModel" | "supportModel" | "executionFallbackModel" {
+  if (row < 3) return "executionModel"
+  if (row < 6) return "supportModel"
+  if (fallbackEnabled && row >= 7 && row <= 9) return "executionFallbackModel"
+  return "executionModel" // shouldn't reach here for effort rows
 }
 
 export function SettingsScreen({ cwd, navigate, config, onConfigChange }: SettingsScreenProps) {
   const [selected, setSelected] = useState(0)
-  const [pickingSlot, setPickingSlot] = useState<"executionModel" | "supportModel" | null>(null)
+  const [pickingSlot, setPickingSlot] = useState<"executionModel" | "supportModel" | "executionFallbackModel" | null>(null)
   const [editingCommand, setEditingCommand] = useState(false)
   const [inputKey, setInputKey] = useState(0)
   const [testStatus, setTestStatus] = useState<string | null>(null)
   const testTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  const fallbackEnabled = config.executionFallbackModel != null
+  const fallbackRows = fallbackEnabled ? 3 : 0 // provider/model/effort when enabled
   const preset = config.notificationPreset
   const isCustom = preset === "custom"
   const notifyEnabled = preset !== "off"
-  const rowCount = notifyEnabled ? (isCustom ? 10 : 9) : 8
+  // 6 base (exec+support) + 1 fallback toggle + fallbackRows + 1 ideas + 1 preset + optional command + optional test
+  const rowCount = 6 + 1 + fallbackRows + 1 + 1 + (notifyEnabled ? (isCustom ? 2 : 1) : 0)
+
+  // Dynamic row indices (shift everything after fallback section)
+  const ROW_FALLBACK_TOGGLE = 6
+  const ROW_FALLBACK_PROVIDER = 7
+  const ROW_FALLBACK_MODEL = 8
+  const ROW_FALLBACK_EFFORT = 9
+  const ROW_IDEAS = 6 + 1 + fallbackRows
+  const ROW_PRESET = ROW_IDEAS + 1
+  const ROW_COMMAND = ROW_PRESET + 1 // only when custom
+  const ROW_TEST = notifyEnabled ? rowCount - 1 : -1
 
   useEffect(() => {
     return () => {
@@ -94,11 +114,12 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
     saveProjectConfig(cwd, next)
   }
 
-  function cycleProvider(slotKey: "executionModel" | "supportModel", direction: -1 | 1) {
+  function cycleProvider(slotKey: "executionModel" | "supportModel" | "executionFallbackModel", direction: -1 | 1) {
     updateConfig((prev) => {
-      const slot = prev[slotKey]
+      const slot = slotKey === "executionFallbackModel"
+        ? (prev.executionFallbackModel ?? DEFAULT_CONFIG.executionModel)
+        : prev[slotKey]
       const nextProvider = cycleChoice(PROVIDER_CHOICES, slot.provider, direction)
-      // Reset model to a sensible default when switching provider
       const defaultModel = nextProvider === "claude" ? "sonnet" : "default"
       const effort = nextProvider === "opencode" ? slot.effort : slot.effort
       return { ...prev, [slotKey]: { provider: nextProvider, model: defaultModel, effort } }
@@ -132,29 +153,40 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
     // Provider rows
     if (selected === 0) return cycleProvider("executionModel", direction)
     if (selected === 3) return cycleProvider("supportModel", direction)
+    if (fallbackEnabled && selected === ROW_FALLBACK_PROVIDER) return cycleProvider("executionFallbackModel", direction)
 
     // Model rows — open picker
-    if (selected === 1 || selected === 4) {
-      setPickingSlot(selected === 1 ? "executionModel" : "supportModel")
+    if (selected === 1) { setPickingSlot("executionModel"); return }
+    if (selected === 4) { setPickingSlot("supportModel"); return }
+    if (fallbackEnabled && selected === ROW_FALLBACK_MODEL) { setPickingSlot("executionFallbackModel"); return }
+
+    // Fallback toggle
+    if (selected === ROW_FALLBACK_TOGGLE) {
+      updateConfig((prev) => ({
+        ...prev,
+        executionFallbackModel: prev.executionFallbackModel != null ? null : { ...DEFAULT_CONFIG.executionModel },
+      }))
       return
     }
 
     // Ideas backlog
-    if (selected === 6) {
+    if (selected === ROW_IDEAS) {
       updateConfig((prev) => ({ ...prev, ideasBacklogEnabled: !prev.ideasBacklogEnabled }))
       return
     }
 
     // Notification preset
-    if (selected === 7) {
+    if (selected === ROW_PRESET) {
       cyclePreset(direction)
       return
     }
 
-    // Effort rows
-    const slotKey = slotKeyForRow(selected)
+    // Effort rows (exec: 2, support: 5, fallback: 9)
+    const slotKey = slotKeyForRow(selected, fallbackEnabled)
     updateConfig((prev) => {
-      const slot = { ...prev[slotKey] }
+      const slot = slotKey === "executionFallbackModel"
+        ? { ...(prev.executionFallbackModel ?? DEFAULT_CONFIG.executionModel) }
+        : { ...prev[slotKey] }
       if (!isEffortConfigurable(slot)) return prev
       const validEfforts = getEffortChoicesForSlot(slot)
       slot.effort = cycleChoice(validEfforts, slot.effort, direction)
@@ -174,10 +206,14 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
     if (key.name === "return") {
       if (selected === 1 || selected === 4) {
         setPickingSlot(selected === 1 ? "executionModel" : "supportModel")
-      } else if (selected === 8 && isCustom) {
+      } else if (fallbackEnabled && selected === ROW_FALLBACK_MODEL) {
+        setPickingSlot("executionFallbackModel")
+      } else if (selected === ROW_FALLBACK_TOGGLE) {
+        cycleValue(1)
+      } else if (isCustom && selected === ROW_COMMAND) {
         setEditingCommand(true)
         setInputKey((k) => k + 1)
-      } else if (notifyEnabled && selected === rowCount - 1) {
+      } else if (notifyEnabled && selected === ROW_TEST) {
         fireTestNotification()
       }
     }
@@ -185,12 +221,18 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
 
   const execSlot = config.executionModel
   const supportSlot = config.supportModel
+  const fallbackSlot = config.executionFallbackModel ?? DEFAULT_CONFIG.executionModel
   const execEffort = formatEffortSlot(execSlot)
   const supportEffort = formatEffortSlot(supportSlot)
+  const fallbackEffort = formatEffortSlot(fallbackSlot)
 
   if (pickingSlot) {
-    const slot = config[pickingSlot]
-    const title = pickingSlot === "executionModel" ? "Execution Model" : "Support Model"
+    const slot: ModelSlot = pickingSlot === "executionFallbackModel"
+      ? (config.executionFallbackModel ?? DEFAULT_CONFIG.executionModel)
+      : config[pickingSlot]
+    const title = pickingSlot === "executionModel" ? "Execution Model"
+      : pickingSlot === "supportModel" ? "Support Model"
+      : "Fallback Model"
     return (
       <ModelPicker
         cwd={cwd}
@@ -198,10 +240,12 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
         providerId={slot.provider}
         onCancel={() => setPickingSlot(null)}
         onSelect={(newSlot) => {
-          updateConfig((prev) => ({
-            ...prev,
-            [pickingSlot]: mergeSelectedModelSlot(prev[pickingSlot], newSlot),
-          }))
+          updateConfig((prev) => {
+            const prevSlot: ModelSlot = pickingSlot === "executionFallbackModel"
+              ? (prev.executionFallbackModel ?? DEFAULT_CONFIG.executionModel)
+              : prev[pickingSlot]
+            return { ...prev, [pickingSlot]: mergeSelectedModelSlot(prevSlot, newSlot) }
+          })
           setPickingSlot(null)
         }}
       />
@@ -260,6 +304,39 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
       />
       <box height={1} />
       <box flexDirection="row">
+        <text><strong>{"  Execution Fallback "}</strong></text>
+        <text fg={colors.textMuted}>{"(auto-switch on quota/rate limits)"}</text>
+      </box>
+      <CycleField
+        label="Fallback Model"
+        value={fallbackEnabled ? "On" : "Off"}
+        description={fallbackEnabled
+          ? "Auto-switch to fallback when primary model hits limits"
+          : "Run stops when primary model hits quota or persistent rate limits"}
+        isFocused={selected === ROW_FALLBACK_TOGGLE}
+      />
+      {fallbackEnabled && (
+        <>
+          <CycleField
+            label="Provider"
+            value={PROVIDER_LABELS[fallbackSlot.provider]}
+            isFocused={selected === ROW_FALLBACK_PROVIDER}
+          />
+          <CycleField
+            label="Model"
+            value={formatModelSlot(fallbackSlot)}
+            isFocused={selected === ROW_FALLBACK_MODEL}
+          />
+          <CycleField
+            label="Effort"
+            value={fallbackEffort.label}
+            description={fallbackEffort.description}
+            isFocused={selected === ROW_FALLBACK_EFFORT}
+          />
+        </>
+      )}
+      <box height={1} />
+      <box flexDirection="row">
         <text><strong>{"  Experiment Memory "}</strong></text>
         <text fg={colors.textMuted}>{"(ideas backlog)"}</text>
       </box>
@@ -269,7 +346,7 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
         description={config.ideasBacklogEnabled
           ? "Capture why experiments worked or failed and what to try next"
           : "Use results.tsv-based experiment memory only"}
-        isFocused={selected === 6}
+        isFocused={selected === ROW_IDEAS}
       />
       <box height={1} />
       <box flexDirection="row">
@@ -279,13 +356,13 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
       <CycleField
         label="Preset"
         value={NOTIFICATION_PRESETS.find((p) => p.id === preset)?.label ?? "Off"}
-        isFocused={selected === 7}
+        isFocused={selected === ROW_PRESET}
       />
       {notifyEnabled && (
         <>
           {isCustom && (
             <box flexDirection="column">
-              {editingCommand && selected === 8 ? (
+              {editingCommand && selected === ROW_COMMAND ? (
                 <box border borderStyle="rounded" height={3}>
                   <input
                     key={inputKey}
@@ -297,27 +374,27 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
                 </box>
               ) : (
                 <text>
-                  {selected === 8 ? (
+                  {selected === ROW_COMMAND ? (
                     <span fg={colors.primary}><strong>{`  Command: ${config.notificationCommand ?? ""}`}</strong></span>
                   ) : (
                     `  Command: ${config.notificationCommand ?? ""}`
                   )}
                 </text>
               )}
-              {selected === 8 && !editingCommand && (
+              {selected === ROW_COMMAND && !editingCommand && (
                 <text fg={colors.textMuted}>{"  Enter to edit \u2022 Variables: {{program}} {{run_id}} {{status}} {{experiments}} {{keeps}} {{best_metric}} {{improvement_pct}} {{duration}}"}</text>
               )}
             </box>
           )}
           <box flexDirection="column">
             <text>
-              {selected === rowCount - 1 ? (
+              {selected === ROW_TEST ? (
                 <span fg={colors.primary}><strong>{`  Test Notification${testStatus ? ` \u2014 ${testStatus}` : ""}`}</strong></span>
               ) : (
                 `  Test Notification${testStatus ? ` \u2014 ${testStatus}` : ""}`
               )}
             </text>
-            {selected === rowCount - 1 && (
+            {selected === ROW_TEST && (
               <text fg={colors.textMuted}>{"  Press Enter to send a test notification with sample data"}</text>
             )}
           </box>


### PR DESCRIPTION
## Summary

- When the primary execution model hits quota exhaustion, auto-switch to a configured fallback model instead of stopping the run
- On persistent rate limits (3 consecutive), switch to fallback; single rate limits still pause and retry
- Provider-limit errors no longer burn experiment slots, increment crash counters, or advance stagnation — they're treated as infrastructure events with experiment number rollback
- Active model persists in `run-config.json` so daemon resume uses the fallback after crash/restart
- `RunState.provider/model/effort` updated on switch so the TUI header reflects the current model automatically
- Settings screen adds "Execution Fallback" section with On/Off toggle + provider/model/effort cycling
- Fallback flows through all entry points: TUI, CLI, and queue

## Files changed

| Area | Files |
|------|-------|
| Config | `config.ts` — `executionFallbackModel` on `ProjectConfig` |
| Persistence | `daemon-lifecycle.ts` — `RunConfig` fallback/active fields, `setActiveModelInRunConfig()` helper |
| Spawn | `daemon-spawn.ts` — threads fallback into `RunConfig` |
| Core loop | `experiment-loop.ts` — fallback logic, `persistModelSwitch()` helper, no-crash-row handling |
| Daemon | `daemon.ts` — reads fallback/active from RunConfig, passes to loop |
| UI | `SettingsScreen.tsx` — fallback model config section |
| Threading | `ExecutionScreen.tsx`, `App.tsx`, `cli.ts`, `queue.ts` |

## Test plan

- [x] `bun typecheck` passes (pre-existing HomeScreen error only)
- [x] `bun lint` — 0 errors from this PR (pre-existing HomeScreen warnings only)
- [x] All 219 tests pass, 0 failures
- [x] Settings screen E2E tests updated for new row layout
- [ ] Manual: configure fallback in Settings, verify it renders correctly
- [ ] Manual: simulate quota exhaustion with mock provider, verify fallback activates without crash row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Execution Fallback" in Settings to specify an alternate model for executions; UI updates reflect enabling/disabling and selecting provider/model/effort.
  * Execution now can automatically switch to the configured fallback model on quota exhaustion or sustained rate limits; execution UI reacts when the fallback setting changes.

* **Tests**
  * Added comprehensive end-to-end tests for queue behavior, concurrency, retries, and daemon startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->