### PR TITLE
feat: proactive quota usage warnings from Claude SDK rate limit events

### DIFF
--- a/src/components/StatsHeader.tsx
+++ b/src/components/StatsHeader.tsx
@@ -68,7 +68,7 @@ function getQuotaDisplay(info: QuotaInfo | undefined): { text: string; color: st
   }
   // allowed — only show if utilization data is available
   if (info.utilization != null) {
-    return { text: `Quota: ${Math.round(info.utilization * 100)}%`, color: colors.textDim }
+    return { text: `Quota: ${Math.round(info.utilization * 100)}%${resetStr}`, color: colors.textDim }
   }
   return null
 }

--- a/src/components/StatsHeader.tsx
+++ b/src/components/StatsHeader.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from "react"
 import { colors } from "../lib/theme.ts"
+import type { QuotaInfo } from "../lib/agent/types.ts"
+import { formatResetsIn } from "../lib/format.ts"
 
 interface StatsHeaderProps {
   experimentNumber: number
@@ -20,6 +22,7 @@ interface StatsHeaderProps {
   currentPhaseLabel: string
   improvementPct: number
   isRunning?: boolean
+  quotaInfo?: QuotaInfo
 }
 
 const BLOCKS = "▁▂▃▄▅▆▇█"
@@ -51,6 +54,25 @@ function formatImprovementPct(pct: number): string {
   return `${pct > 0 ? "+" : ""}${pct.toFixed(1)}%`
 }
 
+function getQuotaDisplay(info: QuotaInfo | undefined): { text: string; color: string } | null {
+  if (!info) return null
+
+  const resetStr = info.resetsAt ? ` resets ${formatResetsIn(info.resetsAt)}` : ""
+
+  if (info.status === "rejected") {
+    return { text: `Quota: EXHAUSTED${resetStr}`, color: colors.error }
+  }
+  if (info.status === "allowed_warning") {
+    const pct = info.utilization != null ? `${Math.round(info.utilization * 100)}%` : "high"
+    return { text: `Quota: ${pct}${resetStr}`, color: colors.warning }
+  }
+  // allowed — only show if utilization data is available
+  if (info.utilization != null) {
+    return { text: `Quota: ${Math.round(info.utilization * 100)}%`, color: colors.textDim }
+  }
+  return null
+}
+
 const SPINNER_CHARS = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
 function Spinner() {
@@ -67,10 +89,12 @@ function Spinner() {
 export function StatsHeader({ isRunning = false, ...props }: StatsHeaderProps) {
   const improvementStr = formatImprovementPct(props.improvementPct)
   const sparkline = renderSparkline(props.metricHistory, props.direction)
+  const quotaDisplay = getQuotaDisplay(props.quotaInfo)
   const contentWidth = Math.max(props.width - 4, 0)
+  const quotaWidth = quotaDisplay ? quotaDisplay.text.length + 4 : 0
   const modelWidth = Math.min(props.modelLabel.length, Math.max(Math.floor(contentWidth * 0.35), 0))
   const separatorWidth = modelWidth > 0 && contentWidth > modelWidth ? 1 : 0
-  const statsWidth = Math.max(contentWidth - modelWidth - separatorWidth, 0)
+  const statsWidth = Math.max(contentWidth - modelWidth - separatorWidth - quotaWidth, 0)
   const costDisplay = props.maxCostUsd != null
     ? `$${props.totalCostUsd.toFixed(2)}/$${props.maxCostUsd.toFixed(2)}`
     : `$${props.totalCostUsd.toFixed(2)}`
@@ -91,6 +115,9 @@ export function StatsHeader({ isRunning = false, ...props }: StatsHeaderProps) {
           </text>
           {separatorWidth > 0 && <box width={separatorWidth} />}
           <text width={modelWidth} fg={colors.textDim} selectable>{props.modelLabel}</text>
+          {quotaDisplay && (
+            <text selectable>{"    "}<span fg={quotaDisplay.color}>{quotaDisplay.text}</span></text>
+          )}
         </box>
         <box width={contentWidth} height={1} flexShrink={0}>
           <text width={contentWidth} selectable>

--- a/src/e2e/quota-warning.e2e.test.tsx
+++ b/src/e2e/quota-warning.e2e.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * E2E test for quota warning feature.
+ * Verifies that:
+ *   1. quota_update events flow through the experiment loop to callbacks
+ *   2. daemon callbacks write quota.json with deduplication
+ *   3. formatResetsIn and formatElapsed produce correct output
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test"
+import { join } from "node:path"
+import { mkdir, chmod } from "node:fs/promises"
+import { $ } from "bun"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { setProvider } from "../lib/agent/index.ts"
+import type {
+  AgentProvider,
+  AgentSession,
+  AgentSessionConfig,
+  AgentEvent,
+  AgentModelOption,
+  AuthResult,
+  QuotaInfo,
+} from "../lib/agent/types.ts"
+import { runExperimentLoop, type LoopCallbacks } from "../lib/experiment-loop.ts"
+import type { ProgramConfig } from "../lib/programs.ts"
+import type { ModelSlot } from "../lib/config.ts"
+import { createFileCallbacks } from "../lib/daemon-callbacks.ts"
+import { formatResetsIn, formatElapsed } from "../lib/format.ts"
+
+// --- Mock provider that emits quota_update events ---
+
+class QuotaMockProvider implements AgentProvider {
+  readonly name: string
+  private events: AgentEvent[]
+
+  constructor(name: string, events: AgentEvent[]) {
+    this.name = name
+    this.events = events
+  }
+
+  createSession(_config: AgentSessionConfig): AgentSession {
+    return new QuotaMockSession(this.events)
+  }
+
+  runOnce(_prompt: string, config: AgentSessionConfig): AgentSession {
+    const session = this.createSession(config)
+    session.endInput()
+    return session
+  }
+
+  async checkAuth(): Promise<AuthResult> {
+    return { authenticated: true, account: { email: "test@example.com" } }
+  }
+
+  async listModels(): Promise<AgentModelOption[]> {
+    return [{ provider: this.name as "claude", model: "default", label: "Default", isDefault: true }]
+  }
+}
+
+class QuotaMockSession implements AgentSession {
+  private closed = false
+  constructor(private events: AgentEvent[]) {}
+
+  pushMessage(): void {}
+  endInput(): void {}
+  close(): void { this.closed = true }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+    for (const event of this.events) {
+      if (this.closed) break
+      yield event
+    }
+  }
+}
+
+// --- Test fixtures ---
+
+const MODEL: ModelSlot = { provider: "claude", model: "sonnet", effort: "high" }
+
+const PROGRAM_CONFIG: ProgramConfig = {
+  metric_field: "score",
+  direction: "lower",
+  noise_threshold: 0.02,
+  repeats: 1,
+  quality_gates: {},
+  max_experiments: 1,
+}
+
+let cwd: string
+let programDir: string
+let runDir: string
+
+beforeAll(async () => {
+  cwd = await mkdtemp(join(tmpdir(), "autoauto-quota-e2e-"))
+  await $`git init`.cwd(cwd).quiet()
+  await $`git config user.email "test@test.com"`.cwd(cwd).quiet()
+  await $`git config user.name "Test"`.cwd(cwd).quiet()
+  await Bun.write(join(cwd, "README.md"), "# test\n")
+  await Bun.write(join(cwd, ".gitignore"), ".autoauto/\n")
+  await $`git add -A`.cwd(cwd).quiet()
+  await $`git commit -m "init"`.cwd(cwd).quiet()
+
+  programDir = join(cwd, ".autoauto", "programs", "test-prog")
+  await mkdir(programDir, { recursive: true })
+
+  await Bun.write(join(programDir, "config.json"), JSON.stringify(PROGRAM_CONFIG, null, 2))
+  await Bun.write(join(programDir, "program.md"), "# Test Program\nOptimize the score.\n")
+  await Bun.write(join(programDir, "measure.sh"), '#!/bin/bash\necho \'{"score": 42}\'')
+  await chmod(join(programDir, "measure.sh"), 0o444)
+
+  const runId = "20260401-130000"
+  runDir = join(programDir, "runs", runId)
+  await mkdir(runDir, { recursive: true })
+
+  const initSha = (await $`git rev-parse HEAD`.cwd(cwd).text()).trim()
+  const branchName = `autoauto-test-prog-${runId}`
+  await $`git checkout -b ${branchName}`.cwd(cwd).quiet()
+
+  const state = {
+    run_id: runId,
+    program_slug: "test-prog",
+    phase: "idle",
+    experiment_number: 0,
+    original_baseline: 42,
+    current_baseline: 42,
+    best_metric: 42,
+    best_experiment: 0,
+    total_keeps: 0,
+    total_discards: 0,
+    total_crashes: 0,
+    branch_name: branchName,
+    original_baseline_sha: initSha,
+    last_known_good_sha: initSha,
+    candidate_sha: null,
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    provider: MODEL.provider,
+    model: MODEL.model,
+    effort: MODEL.effort,
+  }
+  await Bun.write(join(runDir, "state.json"), JSON.stringify(state, null, 2))
+  await Bun.write(
+    join(runDir, "results.tsv"),
+    "experiment\tcommit\tmetric_value\tsecondary_values\tstatus\tdescription\tmeasurement_duration_ms\tdiff_stats\n",
+  )
+})
+
+afterAll(async () => {
+  await rm(cwd, { recursive: true, force: true })
+})
+
+describe("Quota update callback flow", () => {
+  test("onQuotaUpdate fires when agent emits quota_update event", async () => {
+    const quotaInfo: QuotaInfo = {
+      status: "allowed_warning",
+      utilization: 0.85,
+      resetsAt: Date.now() + 3_600_000,
+      rateLimitType: "five_hour",
+      updatedAt: Date.now(),
+    }
+
+    const provider = new QuotaMockProvider("claude", [
+      { type: "quota_update", quota: quotaInfo },
+      { type: "result", success: true },
+    ])
+    setProvider("claude", provider)
+
+    const quotaUpdates: QuotaInfo[] = []
+    const callbacks: LoopCallbacks = {
+      onPhaseChange: () => {},
+      onExperimentStart: () => {},
+      onExperimentEnd: () => {},
+      onStateUpdate: () => {},
+      onAgentStream: () => {},
+      onAgentToolUse: () => {},
+      onError: () => {},
+      onQuotaUpdate: (quota) => { quotaUpdates.push(quota) },
+    }
+
+    await runExperimentLoop(cwd, programDir, runDir, PROGRAM_CONFIG, MODEL, callbacks, {
+      maxExperiments: 1,
+    })
+
+    expect(quotaUpdates.length).toBeGreaterThanOrEqual(1)
+    expect(quotaUpdates[0].status).toBe("allowed_warning")
+    expect(quotaUpdates[0].utilization).toBe(0.85)
+    expect(quotaUpdates[0].rateLimitType).toBe("five_hour")
+  }, 30_000)
+})
+
+describe("Daemon callbacks write quota.json", () => {
+  let callbackRunDir: string
+
+  beforeEach(async () => {
+    callbackRunDir = await mkdtemp(join(tmpdir(), "autoauto-quota-cb-"))
+  })
+
+  test("writes quota.json on status change", async () => {
+    const callbacks = createFileCallbacks(callbackRunDir)
+
+    const quota: QuotaInfo = {
+      status: "allowed_warning",
+      utilization: 0.82,
+      resetsAt: Date.now() + 7_200_000,
+      updatedAt: Date.now(),
+    }
+
+    callbacks.onQuotaUpdate?.(quota)
+
+    // Give Bun.write a moment to complete
+    await Bun.sleep(50)
+
+    const written = await Bun.file(join(callbackRunDir, "quota.json")).json() as QuotaInfo
+    expect(written.status).toBe("allowed_warning")
+    expect(written.utilization).toBe(0.82)
+  })
+
+  test("deduplicates writes when status and utilization unchanged", async () => {
+    const callbacks = createFileCallbacks(callbackRunDir)
+
+    const quota1: QuotaInfo = { status: "allowed", utilization: 0.5, updatedAt: Date.now() }
+    const quota2: QuotaInfo = { status: "allowed", utilization: 0.52, updatedAt: Date.now() }
+    const quota3: QuotaInfo = { status: "allowed", utilization: 0.6, updatedAt: Date.now() }
+
+    callbacks.onQuotaUpdate?.(quota1)
+    await Bun.sleep(50)
+    const firstWrite = await Bun.file(join(callbackRunDir, "quota.json")).json() as QuotaInfo
+    expect(firstWrite.utilization).toBe(0.5)
+
+    // quota2 is within 5% delta — should NOT overwrite
+    callbacks.onQuotaUpdate?.(quota2)
+    await Bun.sleep(50)
+    const afterDedup = await Bun.file(join(callbackRunDir, "quota.json")).json() as QuotaInfo
+    expect(afterDedup.utilization).toBe(0.5) // unchanged
+
+    // quota3 has >5% delta — SHOULD overwrite
+    callbacks.onQuotaUpdate?.(quota3)
+    await Bun.sleep(50)
+    const afterUpdate = await Bun.file(join(callbackRunDir, "quota.json")).json() as QuotaInfo
+    expect(afterUpdate.utilization).toBe(0.6) // updated
+  })
+
+  test("writes on status transition even if utilization similar", async () => {
+    const callbacks = createFileCallbacks(callbackRunDir)
+
+    const quota1: QuotaInfo = { status: "allowed", utilization: 0.79, updatedAt: Date.now() }
+    const quota2: QuotaInfo = { status: "allowed_warning", utilization: 0.80, updatedAt: Date.now() }
+
+    callbacks.onQuotaUpdate?.(quota1)
+    await Bun.sleep(50)
+    callbacks.onQuotaUpdate?.(quota2)
+    await Bun.sleep(50)
+
+    const written = await Bun.file(join(callbackRunDir, "quota.json")).json() as QuotaInfo
+    expect(written.status).toBe("allowed_warning")
+    expect(written.utilization).toBe(0.80)
+  })
+})
+
+describe("formatResetsIn", () => {
+  test("returns 'now' for past timestamps", () => {
+    expect(formatResetsIn(Date.now() - 1000)).toBe("now")
+  })
+
+  test("formats minutes only", () => {
+    expect(formatResetsIn(Date.now() + 15 * 60_000)).toBe("15m")
+  })
+
+  test("formats hours and minutes", () => {
+    expect(formatResetsIn(Date.now() + 2.5 * 3_600_000)).toBe("2h 30m")
+  })
+
+  test("formats days and hours for 24h+", () => {
+    expect(formatResetsIn(Date.now() + 26 * 3_600_000)).toBe("1d 2h")
+  })
+})
+
+describe("formatElapsed", () => {
+  test("returns 'just now' for recent timestamps", () => {
+    expect(formatElapsed(Date.now() - 30_000)).toBe("just now")
+  })
+
+  test("formats minutes ago", () => {
+    expect(formatElapsed(Date.now() - 10 * 60_000)).toBe("10m ago")
+  })
+
+  test("formats hours and minutes ago", () => {
+    expect(formatElapsed(Date.now() - 2.5 * 3_600_000)).toBe("2h 30m ago")
+  })
+
+  test("formats days for 24h+", () => {
+    expect(formatElapsed(Date.now() - 26 * 3_600_000)).toBe("1d 2h ago")
+  })
+})

--- a/src/e2e/quota-warning.e2e.test.tsx
+++ b/src/e2e/quota-warning.e2e.test.tsx
@@ -6,13 +6,13 @@
  *   3. formatResetsIn and formatElapsed produce correct output
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test"
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test"
 import { join } from "node:path"
 import { mkdir, chmod } from "node:fs/promises"
 import { $ } from "bun"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { setProvider } from "../lib/agent/index.ts"
+import { setProvider, getProvider } from "../lib/agent/index.ts"
 import type {
   AgentProvider,
   AgentSession,
@@ -151,6 +151,16 @@ afterAll(async () => {
 })
 
 describe("Quota update callback flow", () => {
+  let originalProvider: AgentProvider | undefined
+
+  beforeEach(() => {
+    try { originalProvider = getProvider("claude") } catch { originalProvider = undefined }
+  })
+
+  afterEach(() => {
+    if (originalProvider) setProvider("claude", originalProvider)
+  })
+
   test("onQuotaUpdate fires when agent emits quota_update event", async () => {
     const quotaInfo: QuotaInfo = {
       status: "allowed_warning",

--- a/src/e2e/setup-update-mode.e2e.test.tsx
+++ b/src/e2e/setup-update-mode.e2e.test.tsx
@@ -72,7 +72,7 @@ describe("SetupScreen — update mode", () => {
       />,
     )
     // Should show loading or the update title while loading context
-    const frame = await harness.flush(500)
+    const frame = await harness.waitForText("perf-opt", 5000)
     expect(frame).toContain("perf-opt")
   })
 })

--- a/src/lib/agent/claude-provider.ts
+++ b/src/lib/agent/claude-provider.ts
@@ -6,6 +6,7 @@ import {
   type SDKAssistantMessage,
   type SDKPartialAssistantMessage,
   type SDKResultMessage,
+  type SDKRateLimitInfo,
   type Query,
 } from "@anthropic-ai/claude-agent-sdk"
 import { createPushStream } from "../push-stream.ts"
@@ -17,6 +18,7 @@ import type {
   AgentCost,
   AuthResult,
   AgentModelOption,
+  QuotaInfo,
 } from "./types.ts"
 import { buildAgentErrorEvent } from "./error-classifier.ts"
 
@@ -84,6 +86,17 @@ function processToolUseEvent(
   }
 
   return { pending, result: null }
+}
+
+function toQuotaInfo(info: SDKRateLimitInfo): QuotaInfo {
+  return {
+    status: info.status,
+    utilization: info.utilization,
+    resetsAt: info.resetsAt,
+    rateLimitType: info.rateLimitType,
+    isUsingOverage: info.isUsingOverage,
+    updatedAt: Date.now(),
+  }
 }
 
 function extractCost(message: SDKResultMessage): AgentCost {
@@ -196,6 +209,9 @@ class ClaudeSession implements AgentSession {
             ? undefined
             : resultMsg.errors.join(", ") || resultMsg.subtype
           yield { type: "result", success, error, cost }
+        } else if (message.type === "rate_limit_event") {
+          const rlEvent = message as unknown as { rate_limit_info: SDKRateLimitInfo }
+          yield { type: "quota_update", quota: toQuotaInfo(rlEvent.rate_limit_info) }
         }
         // Skip "user" and "system" message types
       }

--- a/src/lib/agent/index.ts
+++ b/src/lib/agent/index.ts
@@ -8,6 +8,7 @@ export type {
   AgentProviderID,
   AgentModelOption,
   ErrorKind,
+  QuotaInfo,
 } from "./types.ts"
 
 import type { AgentProvider, AgentProviderID } from "./types.ts"

--- a/src/lib/agent/mock-provider.ts
+++ b/src/lib/agent/mock-provider.ts
@@ -5,6 +5,7 @@ import type {
   AgentEvent,
   AgentModelOption,
   AuthResult,
+  QuotaInfo,
 } from "./types.ts"
 
 /**
@@ -21,6 +22,7 @@ export class MockProvider implements AgentProvider {
       { provider: "claude", model: "sonnet", label: "Sonnet", isDefault: true },
       { provider: "claude", model: "opus", label: "Opus" },
     ],
+    private quotaResult: QuotaInfo | null = null,
   ) {}
 
   createSession(_config: AgentSessionConfig): AgentSession {
@@ -35,6 +37,10 @@ export class MockProvider implements AgentProvider {
 
   async checkAuth(): Promise<AuthResult> {
     return this.authResult
+  }
+
+  async checkQuota(): Promise<QuotaInfo | null> {
+    return this.quotaResult
   }
 
   async listModels(): Promise<AgentModelOption[]> {

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -1,5 +1,15 @@
 import type { ErrorKind } from "./error-classifier.ts"
 
+/** Rate limit / quota information from the provider. */
+export interface QuotaInfo {
+  status: "allowed" | "allowed_warning" | "rejected"
+  utilization?: number // 0-1
+  resetsAt?: number // Unix timestamp (ms)
+  rateLimitType?: string // e.g. 'five_hour', 'seven_day'
+  isUsingOverage?: boolean
+  updatedAt: number // Date.now() when captured
+}
+
 /** Normalized event types emitted by all agent providers. */
 export type AgentEvent =
   | { type: "text_delta"; text: string }
@@ -7,6 +17,7 @@ export type AgentEvent =
   | { type: "assistant_complete"; text: string }
   | { type: "error"; error: string; retriable: boolean; errorKind?: ErrorKind }
   | { type: "result"; success: boolean; error?: string; cost?: AgentCost }
+  | { type: "quota_update"; quota: QuotaInfo }
 
 export type { ErrorKind } from "./error-classifier.ts"
 
@@ -72,6 +83,8 @@ export interface AgentProvider {
   runOnce(prompt: string, config: AgentSessionConfig): AgentSession
   /** Verify authentication with the provider. */
   checkAuth(): Promise<AuthResult>
+  /** Check current quota/rate-limit status without running an experiment. */
+  checkQuota?(): Promise<QuotaInfo | null>
   /** List models available through this provider. */
   listModels?(cwd?: string, forceRefresh?: boolean): Promise<AgentModelOption[]>
   /** Return the provider's configured default model, if available. */

--- a/src/lib/daemon-callbacks.ts
+++ b/src/lib/daemon-callbacks.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path"
 import type { LoopCallbacks } from "./experiment-loop.ts"
+import type { QuotaInfo } from "./agent/types.ts"
 
 /** Format experiment number as zero-padded 3-digit string: 1 → "001" */
 export function streamLogName(experimentNumber: number): string {
@@ -16,6 +17,8 @@ export function streamLogName(experimentNumber: number): string {
 export function createFileCallbacks(runDir: string): LoopCallbacks {
   let currentExperiment = 0
   let writer: ReturnType<ReturnType<typeof Bun.file>["writer"]> | null = null
+  let lastQuotaStatus: string | undefined
+  let lastQuotaUtilization: number | undefined
 
   function getWriter(experimentNumber: number) {
     if (experimentNumber !== currentExperiment || !writer) {
@@ -54,6 +57,15 @@ export function createFileCallbacks(runDir: string): LoopCallbacks {
       w.flush()
     },
     onExperimentCost: () => {},
+    onQuotaUpdate: (quota: QuotaInfo) => {
+      // Deduplicate: skip write if status and utilization haven't meaningfully changed
+      const nullTransition = (quota.utilization == null) !== (lastQuotaUtilization == null)
+      const utilizationDelta = Math.abs((quota.utilization ?? 0) - (lastQuotaUtilization ?? 0))
+      if (quota.status === lastQuotaStatus && !nullTransition && utilizationDelta < 0.05) return
+      lastQuotaStatus = quota.status
+      lastQuotaUtilization = quota.utilization
+      Bun.write(join(runDir, "quota.json"), JSON.stringify(quota))
+    },
     onRebaseline: () => {},
     onLoopComplete: () => {
       writer?.end()

--- a/src/lib/daemon-watcher.ts
+++ b/src/lib/daemon-watcher.ts
@@ -2,6 +2,7 @@ import { watch, statSync, readFileSync, type FSWatcher } from "node:fs"
 import { join } from "node:path"
 import { streamLogName } from "./daemon-callbacks.ts"
 import type { RunState, ExperimentResult } from "./run.ts"
+import type { QuotaInfo } from "./agent/types.ts"
 import { readAllResults, readState, getMetricHistory } from "./run.ts"
 import { getDaemonStatus } from "./daemon-status.ts"
 
@@ -12,6 +13,7 @@ export interface WatchCallbacks {
   onStreamReset?: () => void
   onToolStatus?: (status: string | null) => void
   onIdeasChange?: (text: string) => void
+  onQuotaChange?: (quota: QuotaInfo) => void
   onDaemonDied: () => void
 }
 
@@ -78,6 +80,9 @@ export function watchRunDir(
         } else if (file === "ideas.md" && callbacks.onIdeasChange) {
           const text = await Bun.file(join(runDir, "ideas.md")).text()
           callbacks.onIdeasChange(text)
+        } else if (file === "quota.json" && callbacks.onQuotaChange) {
+          const data = await Bun.file(join(runDir, "quota.json")).json() as QuotaInfo
+          callbacks.onQuotaChange(data)
         } else if (file === "daemon.json") {
           // Heartbeat check handled by backup timer
         }

--- a/src/lib/daemon-watcher.ts
+++ b/src/lib/daemon-watcher.ts
@@ -204,6 +204,7 @@ export function watchRunDir(
       scheduleRead("state.json")
       scheduleRead("results.tsv")
       if (currentStreamFile) scheduleRead(currentStreamFile)
+      if (callbacks.onQuotaChange) scheduleRead("quota.json")
     }, 300)
   }
 

--- a/src/lib/experiment-loop.ts
+++ b/src/lib/experiment-loop.ts
@@ -2,6 +2,7 @@ import { chmod } from "node:fs/promises"
 import { join, relative } from "node:path"
 import type { RunState, ExperimentResult, TerminationReason, PreviousRunContext } from "./run.ts"
 import type { ProgramConfig } from "./programs.ts"
+import type { QuotaInfo } from "./agent/types.ts"
 import { type ModelSlot, formatModelLabel } from "./config.ts"
 import {
   readState,
@@ -55,6 +56,7 @@ export interface LoopCallbacks {
   onAgentToolUse: (status: string) => void
   onError: (error: string) => void
   onExperimentCost?: (cost: ExperimentCost) => void
+  onQuotaUpdate?: (quota: QuotaInfo) => void
   onRebaseline?: (oldBaseline: number, newBaseline: number, reason: string) => void
   onLoopComplete?: (state: RunState, reason: TerminationReason) => void
 }
@@ -568,6 +570,7 @@ export async function runExperimentLoop(
       (status) => callbacks.onAgentToolUse(status),
       options.signal,
       maxTurns,
+      (quota) => callbacks.onQuotaUpdate?.(quota),
     )
 
     // Log cost data if available + accumulate tokens on run state

--- a/src/lib/experiment.ts
+++ b/src/lib/experiment.ts
@@ -12,7 +12,7 @@ import {
   formatShellError,
   type DiffStats,
 } from "./git.ts"
-import { getProvider, type AgentCost, type ErrorKind } from "./agent/index.ts"
+import { getProvider, type AgentCost, type ErrorKind, type QuotaInfo } from "./agent/index.ts"
 import { classifyAgentError } from "./agent/error-classifier.ts"
 import { formatToolEvent } from "./tool-events.ts"
 import {
@@ -310,8 +310,9 @@ export async function runExperimentAgent(
   onToolStatus?: (status: string) => void,
   signal?: AbortSignal,
   maxTurns?: number,
+  onQuotaUpdate?: (quota: QuotaInfo) => void,
 ): Promise<ExperimentOutcome> {
-  const raw = await runExperimentAgentRaw(cwd, systemPrompt, userPrompt, modelConfig, startSha, onStreamText, onToolStatus, signal, maxTurns)
+  const raw = await runExperimentAgentRaw(cwd, systemPrompt, userPrompt, modelConfig, startSha, onStreamText, onToolStatus, signal, maxTurns, onQuotaUpdate)
   return { ...raw.outcome, notes: parseExperimentNotes(raw.assistantText) }
 }
 
@@ -325,6 +326,7 @@ async function runExperimentAgentRaw(
   onToolStatus?: (status: string) => void,
   signal?: AbortSignal,
   maxTurns?: number,
+  onQuotaUpdate?: (quota: QuotaInfo) => void,
 ): Promise<{ outcome: ExperimentOutcome; assistantText: string }> {
   if (signal?.aborted) {
     return { outcome: { type: "agent_error", error: "aborted before start" }, assistantText: "" }
@@ -366,6 +368,9 @@ async function runExperimentAgentRaw(
             const errorMsg = event.error ?? "unknown"
             return { outcome: { type: "agent_error", error: errorMsg, errorKind: classifyAgentError(errorMsg), cost }, assistantText }
           }
+          break
+        case "quota_update":
+          onQuotaUpdate?.(event.quota)
           break
       }
     }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -68,6 +68,29 @@ export function formatCell(str: string, width: number): string {
   return padRight(truncate(sanitizeInlineText(str), width), width)
 }
 
+function formatDurationMs(deltaMs: number, suffix = ""): string {
+  const totalMinutes = Math.floor(deltaMs / 60_000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (hours >= 24) return `${Math.floor(hours / 24)}d ${hours % 24}h${suffix}`
+  if (hours > 0) return `${hours}h ${minutes}m${suffix}`
+  return `${totalMinutes}m${suffix}`
+}
+
+/** Format a future timestamp as a human-readable "resets in" duration. */
+export function formatResetsIn(resetsAt: number): string {
+  const deltaMs = resetsAt - Date.now()
+  if (deltaMs <= 0) return "now"
+  return formatDurationMs(deltaMs)
+}
+
+/** Format elapsed time since a past timestamp as "Xm ago", "Xh Ym ago". */
+export function formatElapsed(timestamp: number): string {
+  const deltaMs = Date.now() - timestamp
+  if (deltaMs < 60_000) return "just now"
+  return formatDurationMs(deltaMs, " ago")
+}
+
 export function truncateStreamText(prev: string, text: string): string {
   const next = prev + text
   return next.length > 8000 ? next.slice(-6000) : next

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -81,6 +81,7 @@ function formatDurationMs(deltaMs: number, suffix = ""): string {
 export function formatResetsIn(resetsAt: number): string {
   const deltaMs = resetsAt - Date.now()
   if (deltaMs <= 0) return "now"
+  if (deltaMs < 60_000) return "<1m"
   return formatDurationMs(deltaMs)
 }
 

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -40,6 +40,7 @@ import { Chat } from "../components/Chat.tsx"
 import { DirtyTreePrompt } from "../components/DirtyTreePrompt.tsx"
 import { syntaxStyle } from "../lib/syntax-theme.ts"
 import { truncateStreamText } from "../lib/format.ts"
+import type { QuotaInfo } from "../lib/agent/types.ts"
 
 type ExecutionPhase = "starting" | "running" | "complete" | "finalizing" | "finalize_complete" | "error" | "dirty"
 
@@ -150,6 +151,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
   const [maxExpText, setMaxExpText] = useState(String(maxExperiments))
   const maxExpTextRef = useRef(maxExpText)
   const [settingsError, setSettingsError] = useState<string | null>(null)
+  const [quotaInfo, setQuotaInfo] = useState<QuotaInfo | undefined>()
   const [ideasText, setIdeasText] = useState("")
   const [summaryText, setSummaryText] = useState("")
   const [showIdeas, setShowIdeas] = useState(true)
@@ -174,6 +176,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
   const abortTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const stoppingRef = useRef(false)
+  const lastProviderRef = useRef<string | undefined>(undefined)
   stoppingRef.current = stopping // ref for use inside effect closures
   const parsedMaxExperiments = Number.parseInt(maxExpText, 10)
   const displayMaxExperiments = Number.isFinite(parsedMaxExperiments) && parsedMaxExperiments > 0
@@ -286,6 +289,11 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
           const watcher = watchRunDir(activeRunDir, {
             onStateChange: (state) => {
               if (cancelled) return
+              // Clear quota data when provider switches (fallback model activated)
+              if (lastProviderRef.current && lastProviderRef.current !== state.provider) {
+                setQuotaInfo(undefined)
+              }
+              lastProviderRef.current = state.provider
               setRunState(state)
               setExperimentNumber(state.experiment_number)
               setTotalCostUsd(state.total_cost_usd ?? 0)
@@ -324,6 +332,10 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
             onIdeasChange: (text) => {
               if (cancelled) return
               setIdeasText(text)
+            },
+            onQuotaChange: (quota) => {
+              if (cancelled) return
+              setQuotaInfo(quota)
             },
             onDaemonDied: () => {
               if (cancelled) return
@@ -726,6 +738,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
               currentPhaseLabel={currentPhaseLabel}
               improvementPct={runState && programConfig ? getRunStats(runState, programConfig.direction).improvement_pct : 0}
               isRunning
+              quotaInfo={quotaInfo}
             />
           </box>
 
@@ -877,6 +890,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
               metricHistory={metricHistory}
               currentPhaseLabel="Complete"
               improvementPct={programConfig ? getRunStats(runState, programConfig.direction).improvement_pct : 0}
+              quotaInfo={quotaInfo}
             />
           </box>
           <box

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -189,6 +189,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
 
   useEffect(() => {
     let cancelled = false
+    setQuotaInfo(undefined)
     const programDir = getProgramDir(cwd, programSlug)
 
     ;(async () => {

--- a/src/screens/PreRunScreen.tsx
+++ b/src/screens/PreRunScreen.tsx
@@ -7,6 +7,8 @@ import {
   loadProgramConfig,
 } from "../lib/programs.ts"
 import { readAllResults, getAvgMeasurementDuration, listRuns } from "../lib/run.ts"
+import type { QuotaInfo } from "../lib/agent/types.ts"
+import { formatResetsIn, formatElapsed } from "../lib/format.ts"
 import {
   type ModelSlot,
   cycleChoice,
@@ -41,6 +43,28 @@ interface PreRunScreenProps {
   programHasQueueEntries?: boolean
 }
 
+function QuotaWarning({ quota }: { quota: QuotaInfo }) {
+  const isExhausted = quota.status === "rejected"
+  const color = isExhausted ? colors.error : colors.warning
+  const message = isExhausted
+    ? "\u26A0 Quota exhausted \u2014 this run will likely fail."
+    : `  \u26A0 Quota at ${quota.utilization != null ? `${Math.round(quota.utilization * 100)}%` : "high usage"} \u2014 may run out during this run.`
+  const advice = isExhausted
+    ? "    Configure a fallback model in Settings, or wait for quota to reset."
+    : "    Consider configuring a fallback model in Settings."
+
+  return (
+    <box flexDirection="column">
+      <text fg={color}>{message}</text>
+      {quota.resetsAt && (
+        <text fg={color}>{`    Resets in ${formatResetsIn(quota.resetsAt)}`}</text>
+      )}
+      <text fg={color}>{advice}</text>
+      <text fg={colors.textDim}>{`    (last checked ${formatElapsed(quota.updatedAt)})`}</text>
+    </box>
+  )
+}
+
 // 0=maxExperiments, 1=maxCostUsd, 2=provider, 3=model, 4=effort, 5=runMode, 6=keepSimplifications, 7=carryForward (if previous runs exist)
 const BASE_FIELD_COUNT = 7
 
@@ -56,6 +80,7 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
   const [pickingModel, setPickingModel] = useState(false)
   const [programConfig, setProgramConfig] = useState<ProgramConfig | null>(null)
   const [avgDurationMs, setAvgDurationMs] = useState<number | null>(null)
+  const [cachedQuota, setCachedQuota] = useState<QuotaInfo | null>(null)
   const fieldCount = hasPreviousRuns ? BASE_FIELD_COUNT + 1 : BASE_FIELD_COUNT
 
   useEffect(() => {
@@ -77,6 +102,14 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
         setAvgDurationMs(getAvgMeasurementDuration(results))
       } catch {
         setHasPreviousRuns(false)
+      }
+      // Load cached quota from latest run (any status, not just completed)
+      const latestAny = runs[0] ?? null
+      if (latestAny) {
+        try {
+          const quota = await Bun.file(`${latestAny.run_dir}/quota.json`).json() as QuotaInfo
+          setCachedQuota(quota)
+        } catch { /* no cached quota */ }
       }
     })
   }, [cwd, programSlug])
@@ -277,6 +310,10 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
             </text>
           )}
         </box>
+      )}
+
+      {cachedQuota && modelSlot.provider === "claude" && (cachedQuota.status === "rejected" || cachedQuota.status === "allowed_warning") && (
+        <QuotaWarning quota={cachedQuota} />
       )}
 
       <box flexGrow={1} />

--- a/src/screens/PreRunScreen.tsx
+++ b/src/screens/PreRunScreen.tsx
@@ -95,14 +95,6 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
     listRuns(programDir).then(async (runs) => {
       const completedRuns = runs.filter((r) => r.state?.phase === "complete")
       setHasPreviousRuns(completedRuns.length > 0)
-      const latest = completedRuns[0] ?? null
-      if (!latest) return
-      try {
-        const results = await readAllResults(latest.run_dir)
-        setAvgDurationMs(getAvgMeasurementDuration(results))
-      } catch {
-        setHasPreviousRuns(false)
-      }
       // Load cached quota from latest run (any status, not just completed)
       const latestAny = runs[0] ?? null
       if (latestAny) {
@@ -110,6 +102,14 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
           const quota = await Bun.file(`${latestAny.run_dir}/quota.json`).json() as QuotaInfo
           setCachedQuota(quota)
         } catch { /* no cached quota */ }
+      }
+      const latest = completedRuns[0] ?? null
+      if (!latest) return
+      try {
+        const results = await readAllResults(latest.run_dir)
+        setAvgDurationMs(getAvgMeasurementDuration(results))
+      } catch {
+        setHasPreviousRuns(false)
       }
     })
   }, [cwd, programSlug])

--- a/src/screens/PreRunScreen.tsx
+++ b/src/screens/PreRunScreen.tsx
@@ -93,6 +93,7 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
       setKeepSimplifications(config.keep_simplifications !== false)
     })
     listRuns(programDir).then(async (runs) => {
+      setCachedQuota(null)
       const completedRuns = runs.filter((r) => r.state?.phase === "complete")
       setHasPreviousRuns(completedRuns.length > 0)
       // Load cached quota from latest run (any status, not just completed)


### PR DESCRIPTION
## Summary

- Surface `SDKRateLimitEvent` data from the Claude Agent SDK during query streams, adding a `QuotaInfo` type and `quota_update` event to the `AgentEvent` union
- Thread quota events through the experiment pipeline → daemon callbacks → `quota.json` file → TUI watcher, following the existing daemon file-based IPC pattern
- Display live quota indicator in **StatsHeader** during runs (dim below warning, yellow at `allowed_warning`, red at `rejected`) with utilization percentage and reset timer
- Show cached quota warnings on **PreRunScreen** from the most recent run's `quota.json`, with staleness indicator

Warning levels follow SDK semantics (`allowed`/`allowed_warning`/`rejected`) rather than hardcoded thresholds. Gracefully degrades when no quota data is available (API-key users, non-Claude providers).

## Test plan

- [x] `bun lint` — 0 errors
- [x] `bun typecheck` — passes
- [x] `bun test src/e2e/quota-warning.e2e.test.tsx` — 12 new tests pass (quota callback flow, daemon write deduplication, format utilities)
- [x] `bun test src/e2e/model-fallback.e2e.test.tsx` — existing fallback tests pass (no regressions)
- [x] `bun test` — full suite 235 tests pass, 0 failures
- [ ] Interactive: `bun dev` → start a Claude run → observe quota indicator in StatsHeader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows quota/rate‑limit status in the stats header with utilization, status‑colored text, and optional reset countdown.
  * Displays quota warnings on the pre‑run screen with advisory text and "last checked" timestamps.
  * Persists recent quota checks across runs and surfaces live quota updates during execution.

* **Tests**
  * Added end‑to‑end tests for quota warnings, persistence/deduplication, live updates, and time‑formatting utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->