### PR TITLE
feat(mcp): add MCP server for external coding agents

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,12 @@
       "name": "autoauto",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/codex-sdk": "^0.118.0",
         "@opencode-ai/sdk": "^1.3.17",
         "@opentui/core": "^0.1.97",
         "@opentui/react": "^0.1.97",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,12 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.118.0",
     "@opencode-ai/sdk": "^1.3.17",
     "@opentui/core": "^0.1.97",
-    "@opentui/react": "^0.1.97"
+    "@opentui/react": "^0.1.97",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "^1.3.11",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1732,6 +1732,13 @@ export async function run(argv: string[]) {
     return
   }
 
+  // MCP server mode — bypass normal CLI dispatch
+  if (argv[0] === "mcp") {
+    const { startMcpServer } = await import("./mcp.ts")
+    await startMcpServer()
+    return
+  }
+
   registerDefaultProviders()
   const args = parseArgs(argv)
   const handler = COMMANDS[args.command]
@@ -1753,6 +1760,7 @@ export async function run(argv: string[]) {
     out("  delete <slug>                 Delete a program or run")
     out("  config                        Show/update project configuration")
     out("  queue [list|add|remove|clear] Manage run queue")
+    out("  mcp                           Start MCP server (stdio transport)")
     out("")
     out("Global flags:")
     out("  --json                        Output as JSON")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ import { closeProviders, type AgentProviderID } from "./lib/agent/index.ts"
 import { registerDefaultProviders } from "./lib/agent/default-providers.ts"
 import { getDefaultModel } from "./lib/model-options.ts"
 import { formatShellError } from "./lib/git.ts"
+import { formatRunDuration, formatChangePct } from "./lib/format.ts"
 import {
   readQueue,
   appendToQueue,
@@ -114,34 +115,9 @@ function padRight(str: string, len: number): string {
   return str.length >= len ? str : str + " ".repeat(len - str.length)
 }
 
-function formatElapsed(startedAt: string, endedAt?: string): string {
-  const start = new Date(startedAt).getTime()
-  const end = endedAt ? new Date(endedAt).getTime() : Date.now()
-  const ms = end - start
-  const mins = Math.floor(ms / 60_000)
-  if (mins < 60) return `${mins}m`
-  const hours = Math.floor(mins / 60)
-  const remainingMins = mins % 60
-  return `${hours}h ${remainingMins}m`
-}
-
 function formatCost(usd: number | undefined): string {
   if (usd == null) return "$0.00"
   return `$${usd.toFixed(2)}`
-}
-
-function formatChangePct(
-  original: number,
-  current: number,
-  direction: ProgramConfig["direction"],
-): string {
-  if (original === 0) return "—"
-  const pct =
-    direction === "lower"
-      ? ((original - current) / Math.abs(original)) * 100
-      : ((current - original) / Math.abs(original)) * 100
-  const sign = pct > 0 ? "+" : ""
-  return `${sign}${pct.toFixed(1)}%`
 }
 
 function parsePositiveInt(value: string): number | null {
@@ -560,7 +536,7 @@ async function cmdStatus(args: ParsedArgs) {
     outJson({
       ...state,
       daemon_alive: daemonAlive,
-      elapsed: formatElapsed(state.started_at, isComplete ? state.updated_at : undefined),
+      elapsed: formatRunDuration(state.started_at, isComplete ? state.updated_at : undefined),
       improvement_pct: stats.improvement_pct,
       keep_rate: stats.keep_rate,
       metric_field: programConfig.metric_field,
@@ -595,7 +571,7 @@ async function cmdStatus(args: ParsedArgs) {
       `Baseline: ${state.original_baseline} → Final best: ${state.best_metric} (${formatChangePct(state.original_baseline, state.best_metric, programConfig.direction)})`,
     )
     out(`Keeps: ${stats.total_keeps} | Discards: ${stats.total_discards} | Crashes: ${stats.total_crashes}`)
-    out(`Cost: ${formatCost(state.total_cost_usd)} | Duration: ${formatElapsed(state.started_at, state.updated_at)}`)
+    out(`Cost: ${formatCost(state.total_cost_usd)} | Duration: ${formatRunDuration(state.started_at, state.updated_at)}`)
     if (state.error) out(`Error: ${state.error}`)
   } else {
     const phaseDetail =
@@ -607,7 +583,7 @@ async function cmdStatus(args: ParsedArgs) {
       `Baseline: ${state.original_baseline} → Current best: ${state.best_metric} (${formatChangePct(state.original_baseline, state.best_metric, programConfig.direction)})`,
     )
     out(`Keeps: ${stats.total_keeps} | Discards: ${stats.total_discards} | Crashes: ${stats.total_crashes}`)
-    out(`Cost: ${formatCost(state.total_cost_usd)} | Elapsed: ${formatElapsed(state.started_at)}`)
+    out(`Cost: ${formatCost(state.total_cost_usd)} | Elapsed: ${formatRunDuration(state.started_at)}`)
   }
 }
 

--- a/src/e2e/stale-run-cleanup.e2e.test.tsx
+++ b/src/e2e/stale-run-cleanup.e2e.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { join } from "node:path"
+import { renderTui, noop, type TuiHarness } from "./helpers.ts"
+import { HomeScreen } from "../screens/HomeScreen.tsx"
+import { resetProjectRoot } from "../lib/programs.ts"
+import { createTestFixture, type TestFixture } from "./fixture.ts"
+import { readState } from "../lib/run.ts"
+
+let harness: TuiHarness | null = null
+
+afterEach(async () => {
+  await harness?.destroy()
+  harness = null
+  resetProjectRoot()
+})
+
+describe("Stale run cleanup on HomeScreen load", () => {
+  let fixture: TestFixture
+
+  afterEach(async () => {
+    await fixture.cleanup()
+  })
+
+  test("run stuck in agent_running with dead daemon is marked crashed", async () => {
+    fixture = await createTestFixture()
+    await fixture.createProgram("stale-prog", {
+      metric_field: "score",
+      direction: "lower",
+      max_experiments: 10,
+    })
+    const runDir = await fixture.createRun("stale-prog", {
+      run_id: "20260401-100000",
+      phase: "agent_running",
+      experiment_number: 2,
+      total_keeps: 0,
+      total_discards: 1,
+    })
+
+    // Write a daemon.json with a dead PID and stale heartbeat to simulate crash
+    await Bun.write(
+      join(runDir, "daemon.json"),
+      JSON.stringify({
+        run_id: "20260401-100000",
+        pid: 999999, // non-existent PID
+        started_at: "2026-04-01T10:00:00.000Z",
+        worktree_path: "/tmp/nonexistent-worktree",
+        daemon_id: "test-dead-daemon",
+        heartbeat_at: "2026-04-01T10:05:00.000Z", // stale
+      }),
+    )
+
+    // Verify state is agent_running before loading HomeScreen
+    const before = await readState(runDir)
+    expect(before.phase).toBe("agent_running")
+
+    // Loading the HomeScreen triggers cleanupStaleRuns
+    harness = await renderTui(
+      <HomeScreen
+        cwd={fixture.cwd}
+        navigate={noop}
+        onSelectProgram={noop}
+        onSelectRun={noop}
+        onUpdateProgram={noop}
+        onFinalizeRun={noop}
+        onResumeDraft={noop}
+      />,
+      { width: 120 },
+    )
+    await harness.waitForText("stale-prog")
+
+    // Verify state was cleaned up on disk
+    const after = await readState(runDir)
+    expect(after.phase).toBe("crashed")
+    expect(after.error_phase).toBe("agent_running")
+  })
+
+  test("stale run becomes deletable after cleanup", async () => {
+    fixture = await createTestFixture()
+    await fixture.createProgram("del-stale", {
+      metric_field: "score",
+      direction: "lower",
+      max_experiments: 10,
+    })
+    const runDir = await fixture.createRun("del-stale", {
+      run_id: "20260401-200000",
+      phase: "measuring",
+      experiment_number: 3,
+    })
+
+    // Write a daemon.json with dead PID
+    await Bun.write(
+      join(runDir, "daemon.json"),
+      JSON.stringify({
+        run_id: "20260401-200000",
+        pid: 999999,
+        started_at: "2026-04-01T10:00:00.000Z",
+        worktree_path: "/tmp/nonexistent-worktree",
+        daemon_id: "test-dead-daemon-2",
+        heartbeat_at: "2026-04-01T10:05:00.000Z",
+      }),
+    )
+
+    harness = await renderTui(
+      <HomeScreen
+        cwd={fixture.cwd}
+        navigate={noop}
+        onSelectProgram={noop}
+        onSelectRun={noop}
+        onUpdateProgram={noop}
+        onFinalizeRun={noop}
+        onResumeDraft={noop}
+      />,
+      { width: 120 },
+    )
+    await harness.waitForText("del-stale")
+
+    // Tab to runs panel, try to delete
+    await harness.tab()
+    await harness.press("d")
+    const frame = await harness.waitForText("Delete this run?")
+    expect(frame).toContain("20260401-200000")
+  })
+
+  test("run without daemon.json is NOT cleaned up", async () => {
+    fixture = await createTestFixture()
+    await fixture.createProgram("no-daemon", {
+      metric_field: "score",
+      direction: "lower",
+      max_experiments: 10,
+    })
+    const runDir = await fixture.createRun("no-daemon", {
+      run_id: "20260401-300000",
+      phase: "idle",
+      experiment_number: 3,
+    })
+
+    // No daemon.json — should not be cleaned up
+    harness = await renderTui(
+      <HomeScreen
+        cwd={fixture.cwd}
+        navigate={noop}
+        onSelectProgram={noop}
+        onSelectRun={noop}
+        onUpdateProgram={noop}
+        onFinalizeRun={noop}
+        onResumeDraft={noop}
+      />,
+      { width: 120 },
+    )
+    await harness.waitForText("no-daemon")
+
+    // State should remain idle (not cleaned up)
+    const after = await readState(runDir)
+    expect(after.phase).toBe("idle")
+  })
+})

--- a/src/lib/daemon-status.ts
+++ b/src/lib/daemon-status.ts
@@ -2,8 +2,8 @@ import { join } from "node:path"
 import { rm } from "node:fs/promises"
 import { $ } from "bun"
 import { streamLogName } from "./daemon-callbacks.ts"
-import type { RunState, ExperimentResult } from "./run.ts"
-import { readAllResults, readState, getMetricHistory, backfillFinalizedAt, listRuns, isRunActive } from "./run.ts"
+import type { RunState, ExperimentResult, RunInfo } from "./run.ts"
+import { readAllResults, readState, getMetricHistory, backfillFinalizedAt, listRuns, isRunActive, writeState } from "./run.ts"
 import type { ProgramConfig } from "./programs.ts"
 import { loadProgramConfig, getProgramDir } from "./programs.ts"
 import {
@@ -270,4 +270,51 @@ export async function abortAndDeleteActiveRuns(
   }
 
   await releaseLock(programDir)
+}
+
+// --- Stale Run Cleanup ---
+
+/**
+ * Detects runs that appear active but whose daemon is dead, and marks them
+ * as crashed. Called from loadHomeData to clean up after daemon crashes that
+ * happened while the TUI wasn't watching (e.g. TUI was closed).
+ *
+ * Only acts when daemon.json exists (proving a daemon once started). Runs
+ * with no daemon.json are left untouched — they may be test fixtures or in
+ * a startup race.
+ *
+ * @param programDir - The program directory (used for lock release)
+ * @param runs - All runs for the program (mutated in-place if cleaned up)
+ */
+export async function cleanupStaleRuns(programDir: string, runs: RunInfo[]): Promise<void> {
+  let cleaned = false
+
+  for (const run of runs) {
+    if (!isRunActive(run) || !run.state) continue
+
+    const status = await getDaemonStatus(run.run_dir)
+    // Only clean up if daemon.json exists (daemon once started) and is now dead
+    if (status.alive || status.starting || !status.daemonJson) continue
+
+    // Daemon is dead but state is non-terminal — mark as crashed
+    const logTail = await readDaemonLogTail(run.run_dir)
+    const crashedState: RunState = {
+      ...run.state,
+      phase: "crashed",
+      error: logTail || "Daemon died unexpectedly",
+      error_phase: run.state.phase,
+      updated_at: new Date().toISOString(),
+    }
+    await writeState(run.run_dir, crashedState)
+    run.state = crashedState // update in-place so callers see the fix
+    cleaned = true
+  }
+
+  if (cleaned) {
+    // Release program lock if no more active runs remain
+    const stillActive = runs.some((r) => isRunActive(r))
+    if (!stillActive) {
+      await releaseLock(programDir)
+    }
+  }
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -96,3 +96,25 @@ export function truncateStreamText(prev: string, text: string): string {
   const next = prev + text
   return next.length > 8000 ? next.slice(-6000) : next
 }
+
+/** Format duration between two ISO date strings (or from startedAt to now). */
+export function formatRunDuration(startedAt: string, endedAt?: string): string {
+  const start = new Date(startedAt).getTime()
+  const end = endedAt ? new Date(endedAt).getTime() : Date.now()
+  return formatDurationMs(end - start)
+}
+
+/** Format metric change as a signed percentage string. */
+export function formatChangePct(
+  original: number,
+  current: number,
+  direction: "lower" | "higher",
+): string {
+  if (original === 0) return "—"
+  const pct =
+    direction === "lower"
+      ? ((original - current) / Math.abs(original)) * 100
+      : ((current - original) / Math.abs(original)) * 100
+  const sign = pct > 0 ? "+" : ""
+  return `${sign}${pct.toFixed(1)}%`
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -28,7 +28,31 @@ import {
   validateProgramConfig,
   type ProgramConfig,
 } from "./lib/programs.ts"
-import { listRuns, isRunActive, deleteProgram } from "./lib/run.ts"
+import {
+  listRuns,
+  isRunActive,
+  deleteProgram,
+  readState,
+  readAllResults,
+  getRunStats,
+  getLatestRun,
+  type RunState,
+} from "./lib/run.ts"
+import {
+  spawnDaemon,
+  getDaemonStatus,
+  sendStop,
+  sendAbort,
+  forceKillDaemon,
+  findActiveRun,
+  updateMaxExperiments,
+} from "./lib/daemon-client.ts"
+import {
+  loadProjectConfig,
+  type ModelSlot,
+} from "./lib/config.ts"
+import { streamLogName } from "./lib/daemon-callbacks.ts"
+import { formatRunDuration, formatChangePct } from "./lib/format.ts"
 
 // ---------------------------------------------------------------------------
 // CWD resolution
@@ -66,6 +90,34 @@ async function readFileOrNull(path: string): Promise<string | null> {
   return null
 }
 
+async function resolveRunDir(
+  programDir: string,
+  runId?: string,
+): Promise<{ runDir: string; runId: string }> {
+  if (runId) {
+    const runDir = join(programDir, "runs", runId)
+    if (!(await Bun.file(join(runDir, "state.json")).exists())) {
+      throw new Error(`Run "${runId}" not found.`)
+    }
+    return { runDir, runId }
+  }
+
+  const latest = await getLatestRun(programDir)
+  if (!latest) throw new Error("No runs found.")
+  return { runDir: latest.run_dir, runId: latest.run_id }
+}
+
+async function resolveProgram(name: string): Promise<{ root: string; programDir: string; programConfig: ProgramConfig }> {
+  const root = await getProjectRoot(CWD)
+  const programDir = getProgramDir(root, name)
+  try {
+    const programConfig = await loadProgramConfig(programDir)
+    return { root, programDir, programConfig }
+  } catch {
+    throw new Error(`Program '${name}' not found.`)
+  }
+}
+
 async function writeScript(path: string, content: string): Promise<void> {
   await Bun.write(path, content)
   await chmod(path, 0o755)
@@ -83,12 +135,10 @@ const server = new McpServer(
     capabilities: { logging: {} },
     instructions: [
       "AutoAuto manages autoresearch programs — autonomous experiment loops that optimize a single metric on any codebase.",
-      "Workflow: (1) get_setup_guide to learn artifact formats,",
-      "(2) list_programs to check for duplicates,",
-      "(3) create_program to write all files,",
-      "(4) validate_measurement to verify stability.",
-      "Use get_program to inspect existing programs, update_program to modify them, delete_program to remove them.",
-    ].join(" "),
+      "Setup workflow: (1) get_setup_guide to learn artifact formats, (2) list_programs to check for duplicates, (3) create_program to write all files, (4) validate_measurement to verify stability.",
+      "Run workflow: (1) start_run to launch an experiment loop, (2) get_run_status to check progress, (3) get_run_results to see experiment outcomes, (4) get_experiment_log for agent output on a specific experiment, (5) stop_run to stop when satisfied.",
+      "Management: list_programs for overview, get_program to inspect, update_program to modify, delete_program to remove. Use list_runs to see run history, update_run_limit to change max experiments mid-run.",
+    ].join("\n"),
   },
 )
 
@@ -618,6 +668,406 @@ server.registerTool(
     } catch (err) {
       return errorResult(`Validation failed: ${err}`)
     }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: start_run
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "start_run",
+  {
+    title: "Start Run",
+    description: [
+      "Start an experiment run for a program.",
+      "Spawns a background daemon that measures a baseline then runs experiments autonomously.",
+      "Returns immediately — use get_run_status to poll for progress.",
+    ].join(" "),
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      provider: z.enum(["claude", "codex", "opencode"]).optional().describe("Agent provider (default: from project config)"),
+      model: z.string().optional().describe("Model name, e.g. 'sonnet', 'opus' (default: from project config)"),
+      effort: z.enum(["low", "medium", "high", "max"]).optional().describe("Effort level (default: from project config)"),
+      max_experiments: z.number().int().min(1).optional().describe("Max experiments (default: from program config)"),
+      use_worktree: z.boolean().default(true).describe("Use git worktree isolation (default true)"),
+      carry_forward: z.boolean().default(true).describe("Carry forward results from previous runs (default true)"),
+    }),
+  },
+  async ({ name, provider, model, effort, max_experiments, use_worktree, carry_forward }) => {
+    let resolved: Awaited<ReturnType<typeof resolveProgram>>
+    try {
+      resolved = await resolveProgram(name)
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+    const { root, programConfig } = resolved
+
+    const projectConfig = await loadProjectConfig(root)
+    const modelConfig: ModelSlot = {
+      provider: provider ?? projectConfig.executionModel.provider,
+      model: model ?? projectConfig.executionModel.model,
+      effort: effort ?? projectConfig.executionModel.effort,
+    }
+    const maxExp = max_experiments ?? programConfig.max_experiments ?? 25
+
+    try {
+      const result = await spawnDaemon(
+        root,
+        name,
+        modelConfig,
+        maxExp,
+        projectConfig.ideasBacklogEnabled,
+        use_worktree,
+        carry_forward,
+        "manual",
+        undefined,  // maxCostUsd
+        undefined,  // keepSimplifications
+        projectConfig.executionFallbackModel,
+      )
+
+      return jsonText({
+        run_id: result.runId,
+        daemon_pid: result.pid,
+        status: "started",
+        message: `Run started. Daemon is measuring baseline, then will run up to ${maxExp} experiments. Use get_run_status to check progress.`,
+      })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return errorResult(`Failed to start run: ${msg}`)
+    }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: get_run_status
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "get_run_status",
+  {
+    title: "Get Run Status",
+    description:
+      "Get the status of the latest (or a specific) run: phase, metrics, progress, cost, and whether the daemon is alive.",
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ name, run_id }) => {
+    let resolved: Awaited<ReturnType<typeof resolveProgram>>
+    try {
+      resolved = await resolveProgram(name)
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+    const { programDir, programConfig } = resolved
+
+    let runDir: string
+    let resolvedRunId: string
+    try {
+      const r = await resolveRunDir(programDir, run_id)
+      runDir = r.runDir
+      resolvedRunId = r.runId
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+
+    let state: RunState
+    try {
+      state = await readState(runDir)
+    } catch {
+      return errorResult(`Could not read state for run "${resolvedRunId}".`)
+    }
+
+    const stats = getRunStats(state, programConfig.direction)
+    const active = await findActiveRun(programDir)
+    const daemonAlive = active?.runId === resolvedRunId && active.daemonAlive
+    const isComplete = state.phase === "complete" || state.phase === "crashed"
+
+    return jsonText({
+      run_id: resolvedRunId,
+      phase: state.phase,
+      daemon_alive: daemonAlive,
+      experiment_number: state.experiment_number,
+      metric_field: programConfig.metric_field,
+      direction: programConfig.direction,
+      original_baseline: state.original_baseline,
+      current_baseline: state.current_baseline,
+      best_metric: state.best_metric,
+      best_experiment: state.best_experiment,
+      improvement: formatChangePct(state.original_baseline, state.best_metric, programConfig.direction),
+      keeps: stats.total_keeps,
+      discards: stats.total_discards,
+      crashes: stats.total_crashes,
+      keep_rate: `${(stats.keep_rate * 100).toFixed(0)}%`,
+      cost_usd: state.total_cost_usd ?? 0,
+      elapsed: formatRunDuration(state.started_at, isComplete ? state.updated_at : undefined),
+      model: state.model ?? null,
+      provider: state.provider ?? null,
+      termination_reason: state.termination_reason ?? null,
+      error: state.error ?? null,
+    })
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: list_runs
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "list_runs",
+  {
+    title: "List Runs",
+    description: "List all runs for a program with summary info (newest first).",
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ name }) => {
+    let resolved: Awaited<ReturnType<typeof resolveProgram>>
+    try {
+      resolved = await resolveProgram(name)
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+    const { programDir, programConfig } = resolved
+
+    const runs = await listRuns(programDir)
+    if (runs.length === 0) return text("No runs found.")
+
+    const result = runs.map((r) => {
+      const s = r.state
+      return {
+        run_id: r.run_id,
+        phase: s?.phase ?? "unknown",
+        experiments: s ? s.total_keeps + s.total_discards + s.total_crashes : 0,
+        best_metric: s?.best_metric ?? null,
+        change: s
+          ? formatChangePct(s.original_baseline, s.best_metric, programConfig.direction)
+          : null,
+      }
+    })
+    return jsonText(result)
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: get_run_results
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "get_run_results",
+  {
+    title: "Get Run Results",
+    description:
+      "Get the experiment results table for a run: experiment number, status (keep/discard/crash), metric value, change %, commit, and description.",
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+      limit: z.number().int().min(1).optional().describe("Return only the last N results"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ name, run_id, limit }) => {
+    let resolved: Awaited<ReturnType<typeof resolveProgram>>
+    try {
+      resolved = await resolveProgram(name)
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+    const { programDir, programConfig } = resolved
+
+    let runDir: string
+    let resolvedRunId: string
+    try {
+      const r = await resolveRunDir(programDir, run_id)
+      runDir = r.runDir
+      resolvedRunId = r.runId
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+
+    const allResults = await readAllResults(runDir)
+    if (allResults.length === 0) {
+      return text("No results yet. Run may still be in baseline phase.")
+    }
+
+    const originalBaseline =
+      allResults.find((r) => r.experiment_number === 0)?.metric_value ?? allResults[0].metric_value
+
+    let results = allResults
+    if (limit != null) {
+      results = allResults.slice(-limit)
+    }
+
+    return jsonText({
+      run_id: resolvedRunId,
+      metric_field: programConfig.metric_field,
+      direction: programConfig.direction,
+      total_results: allResults.length,
+      results: results.map((r) => ({
+        experiment_number: r.experiment_number,
+        status: r.status,
+        metric_value: r.metric_value,
+        change: r.experiment_number === 0
+          ? null
+          : formatChangePct(originalBaseline, r.metric_value, programConfig.direction),
+        commit: r.commit.slice(0, 7),
+        description: r.description,
+        diff_stats: r.diff_stats ?? null,
+      })),
+    })
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: get_experiment_log
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "get_experiment_log",
+  {
+    title: "Get Experiment Log",
+    description:
+      "Get the agent's streaming output (thinking, tool use, code changes) for a specific experiment.",
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      experiment_number: z.union([
+        z.number().int().min(0),
+        z.literal("latest"),
+      ]).describe("Experiment number (0 = baseline) or 'latest'"),
+      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ name, experiment_number, run_id }) => {
+    const root = await getProjectRoot(CWD)
+    const programDir = getProgramDir(root, name)
+
+    if (!(await Bun.file(join(programDir, "config.json")).exists())) {
+      return errorResult(`Program '${name}' not found.`)
+    }
+
+    let runDir: string
+    try {
+      const r = await resolveRunDir(programDir, run_id)
+      runDir = r.runDir
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+
+    let expNum: number
+    if (experiment_number === "latest") {
+      const results = await readAllResults(runDir)
+      if (results.length === 0) return errorResult("No experiments yet.")
+      expNum = results[results.length - 1].experiment_number
+    } else {
+      expNum = experiment_number
+    }
+
+    const logFile = join(runDir, streamLogName(expNum))
+    const f = Bun.file(logFile)
+    if (!(await f.exists())) {
+      return errorResult(`No log found for experiment #${expNum}.`)
+    }
+
+    const logContent = await f.text()
+    return text(logContent || "(empty log)")
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: stop_run
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "stop_run",
+  {
+    title: "Stop Run",
+    description: [
+      "Stop the active run for a program.",
+      "Default: soft stop — waits for the current experiment to finish.",
+      "With abort=true: hard abort — kills agent immediately, records current experiment as crash.",
+    ].join(" "),
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      abort: z.boolean().default(false).describe("Hard abort (default: soft stop)"),
+    }),
+  },
+  async ({ name, abort }) => {
+    const root = await getProjectRoot(CWD)
+    const programDir = getProgramDir(root, name)
+
+    const active = await findActiveRun(programDir)
+    if (!active) return errorResult(`No active run for '${name}'.`)
+    if (!active.daemonAlive) return errorResult("Daemon is not running. Run may have already completed.")
+
+    if (abort) {
+      await sendAbort(active.runDir)
+
+      let alive = true
+      const deadline = Date.now() + 10_000
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 500))
+        const status = await getDaemonStatus(active.runDir)
+        if (!status.alive) { alive = false; break }
+      }
+      if (alive) await forceKillDaemon(active.runDir)
+
+      return jsonText({
+        action: "abort",
+        run_id: active.runId,
+        status: "aborted",
+        message: "Run aborted. Current experiment recorded as crash.",
+      })
+    } else {
+      await sendStop(active.runDir)
+
+      let experimentNum = 0
+      try {
+        const state = await readState(active.runDir)
+        experimentNum = state.experiment_number
+      } catch {}
+
+      return jsonText({
+        action: "stop",
+        run_id: active.runId,
+        status: "stopping",
+        message: `Stop signal sent. Experiment #${experimentNum} will finish, then the run will stop. Use get_run_status to check when it's done.`,
+      })
+    }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: update_run_limit
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "update_run_limit",
+  {
+    title: "Update Run Limit",
+    description:
+      "Update the max experiments cap on an active run. Takes effect at the next iteration boundary.",
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      max_experiments: z.number().int().min(1).describe("New max experiments value"),
+    }),
+  },
+  async ({ name, max_experiments }) => {
+    const root = await getProjectRoot(CWD)
+    const programDir = getProgramDir(root, name)
+
+    const active = await findActiveRun(programDir)
+    if (!active) return errorResult(`No active run for '${name}'.`)
+    if (!active.daemonAlive) return errorResult("Daemon is not running. Run may have already completed.")
+
+    await updateMaxExperiments(active.runDir, max_experiments)
+
+    return jsonText({ run_id: active.runId, max_experiments })
   },
 )
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -726,8 +726,8 @@ server.registerTool(
         use_worktree,
         carry_forward,
         "manual",
-        undefined,  // maxCostUsd
-        undefined,  // keepSimplifications
+        programConfig.max_cost_usd,
+        programConfig.keep_simplifications,
         projectConfig.executionFallbackModel,
       )
 
@@ -1183,8 +1183,5 @@ export async function startMcpServer() {
 
 // Direct execution
 if (import.meta.main) {
-  startMcpServer().catch((err) => {
-    console.error("Fatal:", err)
-    process.exit(1)
-  })
+  await startMcpServer()
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,641 @@
+#!/usr/bin/env bun
+/* eslint-disable no-console */
+/**
+ * AutoAuto MCP Server
+ *
+ * Exposes tools for managing autoresearch programs via the Model Context Protocol.
+ * Primary use case: let a user's coding agent create and configure programs.
+ *
+ * Transport: stdio (spawned as a subprocess by MCP clients)
+ * Launch:    bun run src/mcp.ts [--cwd <project-root>]
+ *            autoauto mcp [--cwd <project-root>]
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { z } from "zod"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { mkdir, chmod } from "node:fs/promises"
+import {
+  listPrograms,
+  loadProgramConfig,
+  getProgramDir,
+  getProgramsDir,
+  getProjectRoot,
+  ensureAutoAutoDir,
+  loadProgramSummaries,
+  validateProgramConfig,
+  type ProgramConfig,
+} from "./lib/programs.ts"
+import { listRuns, isRunActive, deleteProgram } from "./lib/run.ts"
+
+// ---------------------------------------------------------------------------
+// CWD resolution
+// ---------------------------------------------------------------------------
+
+function resolveCwd(): string {
+  const idx = process.argv.indexOf("--cwd")
+  if (idx !== -1 && process.argv[idx + 1]) return process.argv[idx + 1]
+  return process.cwd()
+}
+
+const CWD = resolveCwd()
+
+const VALIDATE_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "lib", "validate-measurement.ts")
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function text(t: string) {
+  return { content: [{ type: "text" as const, text: t }] }
+}
+
+function jsonText(obj: unknown) {
+  return text(JSON.stringify(obj, null, 2))
+}
+
+function errorResult(msg: string) {
+  return { content: [{ type: "text" as const, text: msg }], isError: true as const }
+}
+
+async function readFileOrNull(path: string): Promise<string | null> {
+  const f = Bun.file(path)
+  if (await f.exists()) return f.text()
+  return null
+}
+
+async function writeScript(path: string, content: string): Promise<void> {
+  await Bun.write(path, content)
+  await chmod(path, 0o755)
+}
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json()
+
+const server = new McpServer(
+  { name: "autoauto", version: pkg.version },
+  {
+    capabilities: { logging: {} },
+    instructions: [
+      "AutoAuto manages autoresearch programs — autonomous experiment loops that optimize a single metric on any codebase.",
+      "Workflow: (1) get_setup_guide to learn artifact formats,",
+      "(2) list_programs to check for duplicates,",
+      "(3) create_program to write all files,",
+      "(4) validate_measurement to verify stability.",
+      "Use get_program to inspect existing programs, update_program to modify them, delete_program to remove them.",
+    ].join(" "),
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: list_programs
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "list_programs",
+  {
+    title: "List Programs",
+    description:
+      "List all autoresearch programs in the project with their goals and run counts.",
+    inputSchema: z.object({}),
+    annotations: { readOnlyHint: true },
+  },
+  async () => {
+    const root = await getProjectRoot(CWD)
+    const programs = await listPrograms(CWD)
+    if (programs.length === 0) return text("No programs found.")
+
+    const summaries = await loadProgramSummaries(CWD)
+    const summaryMap = new Map(summaries.map((s) => [s.slug, s.goal]))
+
+    const result = await Promise.all(
+      programs.map(async (p) => {
+        const programDir = getProgramDir(root, p.name)
+        const runs = await listRuns(programDir)
+        const activeRun = runs.find(isRunActive)
+        return {
+          name: p.name,
+          goal: summaryMap.get(p.name) ?? "(unknown)",
+          totalRuns: runs.length,
+          hasActiveRun: !!activeRun,
+        }
+      }),
+    )
+    return jsonText(result)
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: get_program
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "get_program",
+  {
+    title: "Get Program Details",
+    description:
+      "Get the full details of a program: config.json, program.md, measure.sh, and build.sh.",
+    inputSchema: z.object({
+      name: z.string().describe("Program slug (e.g. 'homepage-lcp')"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ name }) => {
+    const root = await getProjectRoot(CWD)
+    const programDir = getProgramDir(root, name)
+
+    let config: ProgramConfig
+    try {
+      config = await loadProgramConfig(programDir)
+    } catch (err) {
+      return errorResult(`Program '${name}' not found or invalid config: ${err}`)
+    }
+
+    const [programMd, measureSh, buildSh] = await Promise.all([
+      readFileOrNull(join(programDir, "program.md")),
+      readFileOrNull(join(programDir, "measure.sh")),
+      readFileOrNull(join(programDir, "build.sh")),
+    ])
+
+    return jsonText({
+      name,
+      config,
+      program_md: programMd,
+      measure_sh: measureSh,
+      build_sh: buildSh,
+    })
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: get_setup_guide
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "get_setup_guide",
+  {
+    title: "Get Setup Guide",
+    description: [
+      "Get the complete guide for creating AutoAuto programs.",
+      "Includes artifact formats (program.md, measure.sh, build.sh, config.json),",
+      "measurement requirements, quality gate design, and autoresearch best practices.",
+      "Read this BEFORE calling create_program.",
+    ].join(" "),
+    inputSchema: z.object({}),
+    annotations: { readOnlyHint: true },
+  },
+  async () => {
+    const root = await getProjectRoot(CWD)
+    const programsDir = getProgramsDir(root)
+
+    const guide = `# AutoAuto Program Setup Guide
+
+## What is an AutoAuto Program?
+
+An optimization program defines a repeatable, measurable experiment loop that an AI agent runs autonomously to improve a specific metric. Each program has:
+- **program.md** — Goal, scope, rules, and steps for the agent
+- **measure.sh** — Script that outputs a single JSON object with the metric
+- **build.sh** (optional) — Build/compile step that runs once before measurements
+- **config.json** — Metric configuration, quality gates, and tuning parameters
+
+## Key Principles
+
+- **One metric, one direction, one target.** Every program optimizes exactly one number. Narrow is better — "reduce homepage JS chunk size in bytes" beats "reduce bundle size."
+- **Scope is safety.** The experiment agent will exploit any loophole. Tight scope prevents metric gaming.
+- **Measurement must be fast and stable.** The script runs hundreds of times. It should complete in seconds, not minutes.
+- **Binary over sliding scale.** For subjective metrics, prefer binary yes/no criteria over 1-7 scales.
+
+## Program Directory Structure
+
+Programs live in: ${programsDir}/<slug>/
+\`\`\`
+${programsDir}/<slug>/
+├── program.md      # Goal, scope, rules, steps
+├── measure.sh      # Measurement script (chmod +x)
+├── build.sh        # Optional build step (chmod +x)
+└── config.json     # Metric configuration
+\`\`\`
+
+## Artifact Formats
+
+### program.md
+
+\`\`\`markdown
+# Program: <Human-Readable Name>
+
+## Goal
+<One clear sentence describing what to optimize and in what direction.>
+
+## Scope
+- Files: <specific files or glob patterns the experiment agent may modify>
+- Off-limits: <files, directories, or systems the agent must NOT touch>
+
+## Rules
+<Numbered list of constraints. Be specific.>
+1. Do not remove features or functionality
+2. Do not modify test fixtures or test data
+3. Do not change the public API surface
+4. <domain-specific constraints>
+
+## Steps
+1. ANALYZE: Read the codebase within scope, review results.tsv for past experiments
+2. PLAN: Choose ONE specific, targeted change
+3. IMPLEMENT: Make the change, keeping the diff small and focused
+4. TEST: Verify the change doesn't break anything
+5. COMMIT: Stage and commit with message format: "<type>(scope): description"
+\`\`\`
+
+### measure.sh
+
+\`\`\`bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# <Brief description of what this measures>
+# Output: JSON object with metric fields
+
+<measurement logic — assumes project is already built>
+
+# Output MUST be a single JSON object on stdout, nothing else
+echo '{"<metric_field>": <value>}'
+\`\`\`
+
+Requirements:
+- Shebang + \`set -euo pipefail\`
+- stdout: exactly ONE JSON object, nothing else (logs go to stderr)
+- Exit 0 on success, nonzero on failure
+- Must complete in <30 seconds ideally
+- Must be deterministic: lock random seeds, avoid network calls
+- All quality gate and secondary metric fields must be present as finite numbers
+- NEVER hardcode absolute home paths — use relative paths or \`$HOME\`
+
+### build.sh (optional)
+
+\`\`\`bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build step — runs ONCE before measurement runs
+# MUST install dependencies (npm ci, bun install, etc.)
+<build logic>
+\`\`\`
+
+Only needed when the project has a build/compile step.
+
+### config.json
+
+\`\`\`json
+{
+  "metric_field": "<key from measure.sh JSON output>",
+  "direction": "lower|higher",
+  "noise_threshold": 0.02,
+  "repeats": 3,
+  "max_experiments": 20,
+  "quality_gates": {
+    "<field_name>": { "min": 1.0 }
+  },
+  "secondary_metrics": {
+    "<field_name>": { "direction": "lower|higher" }
+  }
+}
+\`\`\`
+
+Field reference:
+- \`metric_field\`: Key in measure.sh JSON output to optimize
+- \`direction\`: "lower" or "higher" — which direction is better
+- \`noise_threshold\`: Minimum relative improvement to keep (decimal: 0.02 = 2%)
+- \`repeats\`: Measurements per experiment (3 for stable, 5 for noisy)
+- \`max_experiments\`: Cap per run (20 default; 10-15 for expensive, 50+ for cheap)
+- \`quality_gates\`: Hard pass/fail constraints — experiment discarded if gate fails
+- \`secondary_metrics\`: Advisory metrics tracked but not gating (direction required)
+- \`max_consecutive_discards\`: (optional) Auto-stop after N consecutive non-improving experiments (default 10)
+- \`measurement_timeout\`: (optional) Timeout in ms for each measure.sh run (default 60000)
+- \`build_timeout\`: (optional) Timeout in ms for build.sh (default 600000)
+- \`max_cost_usd\`: (optional) Cost cap per run
+
+## Measurement Design Tips
+
+- If the metric is naturally deterministic (byte count, line count), noise_threshold=0.01 and repeats=1 may suffice
+- For tool-based metrics (Lighthouse, benchmarks), use repeats=3 minimum
+- Flag potential noise sources: cold starts, network calls, random seeds, caching
+- measure.sh can write \`.autoauto-diagnostics\` sidecar file for rich context to the agent
+
+## Quality Gate Design
+
+- Suggest gates based on what could break when optimizing the primary metric
+- Test pass rate is a common default gate: \`"test_pass_rate": { "min": 1.0 }\`
+- Keep gates focused — too many gates leads to checklist gaming
+- Prefer binary pass/fail over threshold-based gates
+
+## Anti-Gaming Rules
+
+Think about how the agent could game the metric and add rules against it:
+- Bundle size → agent might delete features or replace libraries with stubs
+- Test coverage → agent might add trivial tests
+- Latency → agent might remove error handling or validation
+- Line count → agent might minify code or remove comments
+
+## Expectations
+
+- 5-25% keep rate is normal (most experiments get discarded)
+- ~$0.05-0.20/experiment, ~$5-10 for 50 experiments
+- ~12 experiments/hour at a 5-minute eval budget
+
+## After Creating a Program
+
+Always run validate_measurement to verify the measurement script works and check variance (CV%).`
+
+    return text(guide)
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: create_program
+// ---------------------------------------------------------------------------
+
+const QualityGateSchema = z.object({
+  min: z.number().optional().describe("Minimum threshold (experiment discarded if below)"),
+  max: z.number().optional().describe("Maximum threshold (experiment discarded if above)"),
+}).describe("At least one of min or max required")
+
+const SecondaryMetricSchema = z.object({
+  direction: z.enum(["lower", "higher"]).describe("Which direction is better"),
+})
+
+const ConfigSchema = z.object({
+  metric_field: z.string().min(1).describe("Key in measure.sh JSON output to optimize"),
+  direction: z.enum(["lower", "higher"]).describe("Which direction is better"),
+  noise_threshold: z.number().positive().describe("Minimum relative improvement to keep (decimal: 0.02 = 2%)"),
+  repeats: z.number().int().min(1).describe("Measurements per experiment (3 for stable, 5 for noisy)"),
+  max_experiments: z.number().int().min(1).describe("Max experiments per run"),
+  quality_gates: z.record(z.string(), QualityGateSchema).default({}).describe("Hard pass/fail constraints"),
+  secondary_metrics: z.record(z.string(), SecondaryMetricSchema).optional().describe("Advisory metrics (tracked, not gating)"),
+  max_consecutive_discards: z.number().int().min(1).optional().describe("Auto-stop after N consecutive non-improving experiments"),
+  measurement_timeout: z.number().int().min(1000).optional().describe("Timeout in ms for each measure.sh run"),
+  build_timeout: z.number().int().min(1000).optional().describe("Timeout in ms for build.sh"),
+  max_cost_usd: z.number().positive().optional().describe("Cost cap per run in USD"),
+  max_turns: z.number().int().min(1).optional().describe("Max agent turns per experiment"),
+  keep_simplifications: z.boolean().optional().describe("Keep experiments that simplify code without improving metric"),
+  finalize_risk_assessment: z.boolean().optional().describe("Run risk assessment during finalization"),
+})
+
+server.registerTool(
+  "create_program",
+  {
+    title: "Create Program",
+    description: [
+      "Create a new autoresearch program with all required files.",
+      "Writes program.md, measure.sh, config.json, and optionally build.sh.",
+      "Call get_setup_guide first to understand the artifact formats.",
+      "After creating, call validate_measurement to verify it works.",
+    ].join(" "),
+    inputSchema: z.object({
+      name: z
+        .string()
+        .min(1)
+        .regex(/^[a-z0-9-]+$/, "Must be lowercase letters, numbers, and hyphens only")
+        .describe("Program slug (e.g. 'homepage-lcp')"),
+      program_md: z.string().min(1).describe("Full contents of program.md"),
+      measure_sh: z.string().min(1).describe("Full contents of measure.sh"),
+      build_sh: z.string().optional().describe("Full contents of build.sh (optional)"),
+      config: ConfigSchema.describe("Program configuration (becomes config.json)"),
+    }),
+    annotations: { destructiveHint: false, idempotentHint: false },
+  },
+  async ({ name, program_md, measure_sh, build_sh, config }) => {
+    const root = await getProjectRoot(CWD)
+    const programDir = getProgramDir(root, name)
+
+    // Check for existing program
+    if (await Bun.file(join(programDir, "config.json")).exists()) {
+      return errorResult(
+        `Program '${name}' already exists. Use update_program to modify it, or choose a different name.`,
+      )
+    }
+
+    // Validate config through the same validator the rest of the system uses
+    try {
+      validateProgramConfig(config)
+    } catch (err) {
+      return errorResult(`Invalid config: ${err}`)
+    }
+
+    // Ensure .autoauto directory and .gitignore
+    await ensureAutoAutoDir(CWD)
+
+    // Create program directory
+    await mkdir(programDir, { recursive: true })
+
+    // Write files (independent, run in parallel)
+    await Promise.all([
+      Bun.write(join(programDir, "program.md"), program_md),
+      writeScript(join(programDir, "measure.sh"), measure_sh),
+      ...(build_sh ? [writeScript(join(programDir, "build.sh"), build_sh)] : []),
+      Bun.write(join(programDir, "config.json"), JSON.stringify(config, null, 2) + "\n"),
+    ])
+
+    return text(
+      `Program '${name}' created at .autoauto/programs/${name}/.\n\n` +
+        `Files written:\n` +
+        `  - program.md\n` +
+        `  - measure.sh\n` +
+        (build_sh ? `  - build.sh\n` : "") +
+        `  - config.json\n\n` +
+        `Next step: call validate_measurement to verify the measurement script works and check variance.`,
+    )
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: update_program
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "update_program",
+  {
+    title: "Update Program",
+    description:
+      "Update specific files in an existing program. Only the provided fields are overwritten.",
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      program_md: z.string().optional().describe("New contents of program.md"),
+      measure_sh: z.string().optional().describe("New contents of measure.sh"),
+      build_sh: z.string().optional().describe("New contents of build.sh"),
+      config: ConfigSchema.optional().describe("New config.json contents"),
+    }),
+    annotations: { destructiveHint: false, idempotentHint: true },
+  },
+  async ({ name, program_md, measure_sh, build_sh, config }) => {
+    const root = await getProjectRoot(CWD)
+    const programDir = getProgramDir(root, name)
+
+    if (!(await Bun.file(join(programDir, "config.json")).exists())) {
+      return errorResult(`Program '${name}' not found.`)
+    }
+
+    const updated: string[] = []
+
+    if (program_md !== undefined) {
+      await Bun.write(join(programDir, "program.md"), program_md)
+      updated.push("program.md")
+    }
+    if (measure_sh !== undefined) {
+      await writeScript(join(programDir, "measure.sh"), measure_sh)
+      updated.push("measure.sh")
+    }
+    if (build_sh !== undefined) {
+      await writeScript(join(programDir, "build.sh"), build_sh)
+      updated.push("build.sh")
+    }
+    if (config !== undefined) {
+      try {
+        validateProgramConfig(config)
+      } catch (err) {
+        return errorResult(`Invalid config: ${err}`)
+      }
+      await Bun.write(join(programDir, "config.json"), JSON.stringify(config, null, 2) + "\n")
+      updated.push("config.json")
+    }
+
+    if (updated.length === 0) {
+      return text("No files were provided to update.")
+    }
+
+    return text(
+      `Updated ${updated.join(", ")} in program '${name}'.\n\n` +
+        (updated.includes("measure.sh") || updated.includes("config.json")
+          ? "Tip: run validate_measurement to re-check measurement stability."
+          : ""),
+    )
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: delete_program
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "delete_program",
+  {
+    title: "Delete Program",
+    description:
+      "Permanently delete a program and all its runs. Cannot delete a program with an active run.",
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      confirm: z.literal(true).describe("Must be true to confirm deletion"),
+    }),
+    annotations: { destructiveHint: true },
+  },
+  async ({ name }) => {
+    const root = await getProjectRoot(CWD)
+    const programDir = getProgramDir(root, name)
+
+    if (!(await Bun.file(join(programDir, "config.json")).exists())) {
+      return errorResult(`Program '${name}' not found.`)
+    }
+
+    try {
+      await deleteProgram(root, name)
+    } catch (err) {
+      return errorResult(`${err instanceof Error ? err.message : String(err)}`)
+    }
+
+    return text(`Program '${name}' and all its runs have been deleted.`)
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: validate_measurement
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "validate_measurement",
+  {
+    title: "Validate Measurement",
+    description: [
+      "Run the measurement validation script for a program.",
+      "Creates a temporary git worktree, runs build.sh + measure.sh multiple times,",
+      "and reports CV%, assessment (deterministic/excellent/acceptable/noisy/unstable),",
+      "and recommended config values.",
+    ].join(" "),
+    inputSchema: z.object({
+      name: z.string().min(1).describe("Program slug"),
+      runs: z.number().int().min(1).max(20).default(5).describe("Number of measurement runs (default 5)"),
+    }),
+  },
+  async ({ name, runs }) => {
+    const root = await getProjectRoot(CWD)
+    const programDir = getProgramDir(root, name)
+    const measureSh = join(programDir, "measure.sh")
+    const configJson = join(programDir, "config.json")
+
+    if (!(await Bun.file(measureSh).exists())) {
+      return errorResult(`Program '${name}' not found or missing measure.sh.`)
+    }
+
+    try {
+      const proc = Bun.spawn(
+        ["bun", "run", VALIDATE_SCRIPT, measureSh, configJson, String(runs)],
+        {
+          cwd: root,
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      )
+
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ])
+
+      const exitCode = await proc.exited
+
+      if (exitCode !== 0 && !stdout.trim()) {
+        return errorResult(`Validation script exited with code ${exitCode}\n\nstderr:\n${stderr}`)
+      }
+
+      if (!stdout.trim()) {
+        return errorResult(`Validation produced no output.\n\nstderr:\n${stderr}`)
+      }
+
+      let result: unknown
+      try {
+        result = JSON.parse(stdout)
+      } catch {
+        return errorResult(`Validation output was not valid JSON:\n${stdout}\n\nstderr:\n${stderr}`)
+      }
+
+      // Return the structured result plus stderr progress
+      return jsonText({
+        validation: result,
+        ...(stderr.trim() ? { progress_log: stderr.trim() } : {}),
+      })
+    } catch (err) {
+      return errorResult(`Validation failed: ${err}`)
+    }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+export async function startMcpServer() {
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+  // All logging must go to stderr — stdout is the MCP protocol channel
+  console.error(`AutoAuto MCP server running (cwd: ${CWD})`)
+}
+
+// Direct execution
+if (import.meta.main) {
+  startMcpServer().catch((err) => {
+    console.error("Fatal:", err)
+    process.exit(1)
+  })
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -68,6 +68,9 @@ const CWD = resolveCwd()
 
 const VALIDATE_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "lib", "validate-measurement.ts")
 
+/** Reusable slug schema — prevents path traversal via names like "../../etc" */
+const SlugSchema = z.string().min(1).regex(/^[a-z0-9-]+$/, "Must be lowercase letters, numbers, and hyphens only")
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -191,7 +194,7 @@ server.registerTool(
     description:
       "Get the full details of a program: config.json, program.md, measure.sh, and build.sh.",
     inputSchema: z.object({
-      name: z.string().describe("Program slug (e.g. 'homepage-lcp')"),
+      name: SlugSchema.describe("Program slug (e.g. 'homepage-lcp')"),
     }),
     annotations: { readOnlyHint: true },
   },
@@ -417,6 +420,7 @@ const SecondaryMetricSchema = z.object({
   direction: z.enum(["lower", "higher"]).describe("Which direction is better"),
 })
 
+// Keep in sync with validateProgramConfig() in programs.ts — both validate config shape
 const ConfigSchema = z.object({
   metric_field: z.string().min(1).describe("Key in measure.sh JSON output to optimize"),
   direction: z.enum(["lower", "higher"]).describe("Which direction is better"),
@@ -445,11 +449,7 @@ server.registerTool(
       "After creating, call validate_measurement to verify it works.",
     ].join(" "),
     inputSchema: z.object({
-      name: z
-        .string()
-        .min(1)
-        .regex(/^[a-z0-9-]+$/, "Must be lowercase letters, numbers, and hyphens only")
-        .describe("Program slug (e.g. 'homepage-lcp')"),
+      name: SlugSchema.describe("Program slug (e.g. 'homepage-lcp')"),
       program_md: z.string().min(1).describe("Full contents of program.md"),
       measure_sh: z.string().min(1).describe("Full contents of measure.sh"),
       build_sh: z.string().optional().describe("Full contents of build.sh (optional)"),
@@ -512,7 +512,7 @@ server.registerTool(
     description:
       "Update specific files in an existing program. Only the provided fields are overwritten.",
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       program_md: z.string().optional().describe("New contents of program.md"),
       measure_sh: z.string().optional().describe("New contents of measure.sh"),
       build_sh: z.string().optional().describe("New contents of build.sh"),
@@ -576,7 +576,7 @@ server.registerTool(
     description:
       "Permanently delete a program and all its runs. Cannot delete a program with an active run.",
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       confirm: z.literal(true).describe("Must be true to confirm deletion"),
     }),
     annotations: { destructiveHint: true },
@@ -614,7 +614,7 @@ server.registerTool(
       "and recommended config values.",
     ].join(" "),
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       runs: z.number().int().min(1).max(20).default(5).describe("Number of measurement runs (default 5)"),
     }),
   },
@@ -685,7 +685,7 @@ server.registerTool(
       "Returns immediately — use get_run_status to poll for progress.",
     ].join(" "),
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       provider: z.enum(["claude", "codex", "opencode"]).optional().describe("Agent provider (default: from project config)"),
       model: z.string().optional().describe("Model name, e.g. 'sonnet', 'opus' (default: from project config)"),
       effort: z.enum(["low", "medium", "high", "max"]).optional().describe("Effort level (default: from project config)"),
@@ -750,7 +750,7 @@ server.registerTool(
     description:
       "Get the status of the latest (or a specific) run: phase, metrics, progress, cost, and whether the daemon is alive.",
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       run_id: z.string().optional().describe("Specific run ID (default: latest)"),
     }),
     annotations: { readOnlyHint: true },
@@ -822,7 +822,7 @@ server.registerTool(
     title: "List Runs",
     description: "List all runs for a program with summary info (newest first).",
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
     }),
     annotations: { readOnlyHint: true },
   },
@@ -865,7 +865,7 @@ server.registerTool(
     description:
       "Get the experiment results table for a run: experiment number, status (keep/discard/crash), metric value, change %, commit, and description.",
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       run_id: z.string().optional().describe("Specific run ID (default: latest)"),
       limit: z.number().int().min(1).optional().describe("Return only the last N results"),
     }),
@@ -934,7 +934,7 @@ server.registerTool(
     description:
       "Get the agent's streaming output (thinking, tool use, code changes) for a specific experiment.",
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       experiment_number: z.union([
         z.number().int().min(0),
         z.literal("latest"),
@@ -993,7 +993,7 @@ server.registerTool(
       "With abort=true: hard abort — kills agent immediately, records current experiment as crash.",
     ].join(" "),
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       abort: z.boolean().default(false).describe("Hard abort (default: soft stop)"),
     }),
   },
@@ -1053,7 +1053,7 @@ server.registerTool(
     description:
       "Update the max experiments cap on an active run. Takes effect at the next iteration boundary.",
     inputSchema: z.object({
-      name: z.string().min(1).describe("Program slug"),
+      name: SlugSchema.describe("Program slug"),
       max_experiments: z.number().int().min(1).describe("New max experiments value"),
     }),
   },

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -582,7 +582,11 @@ server.registerTool(
     }),
     annotations: { destructiveHint: true },
   },
-  async ({ name }) => {
+  async ({ name, confirm }) => {
+    if (!confirm) {
+      return errorResult("Deletion requires confirm=true.")
+    }
+
     const root = await getProjectRoot(CWD)
     const programDir = getProgramDir(root, name)
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -53,6 +53,7 @@ import {
 } from "./lib/config.ts"
 import { streamLogName } from "./lib/daemon-callbacks.ts"
 import { formatRunDuration, formatChangePct } from "./lib/format.ts"
+import { generateSummaryReport, saveFinalizeReport } from "./lib/finalize.ts"
 
 // ---------------------------------------------------------------------------
 // CWD resolution
@@ -139,7 +140,7 @@ const server = new McpServer(
     instructions: [
       "AutoAuto manages autoresearch programs — autonomous experiment loops that optimize a single metric on any codebase.",
       "Setup workflow: (1) get_setup_guide to learn artifact formats, (2) list_programs to check for duplicates, (3) create_program to write all files, (4) validate_measurement to verify stability.",
-      "Run workflow: (1) start_run to launch an experiment loop, (2) get_run_status to check progress, (3) get_run_results to see experiment outcomes, (4) get_experiment_log for agent output on a specific experiment, (5) stop_run to stop when satisfied.",
+      "Run workflow: (1) start_run to launch an experiment loop, (2) get_run_status to check progress, (3) get_run_results to see experiment outcomes, (4) get_experiment_log for agent output on a specific experiment, (5) stop_run to stop when satisfied, (6) get_run_summary for a post-run report.",
       "Management: list_programs for overview, get_program to inspect, update_program to modify, delete_program to remove. Use list_runs to see run history, update_run_limit to change max experiments mid-run.",
     ].join("\n"),
   },
@@ -1068,6 +1069,100 @@ server.registerTool(
     await updateMaxExperiments(active.runDir, max_experiments)
 
     return jsonText({ run_id: active.runId, max_experiments })
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: get_run_summary
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "get_run_summary",
+  {
+    title: "Get Run Summary",
+    description: [
+      "Get a summary report for a completed run.",
+      "Returns the existing summary if available, or generates a stats-based summary with generate=true.",
+      "Only completed or crashed runs can have summaries generated.",
+    ].join(" "),
+    inputSchema: z.object({
+      name: SlugSchema.describe("Program slug"),
+      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+      generate: z.boolean().default(false).describe("Generate stats summary if none exists (only for completed/crashed runs)"),
+    }),
+    annotations: { readOnlyHint: false },
+  },
+  async ({ name, run_id, generate }) => {
+    let resolved: Awaited<ReturnType<typeof resolveProgram>>
+    try {
+      resolved = await resolveProgram(name)
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+    const { programDir, programConfig } = resolved
+
+    let runDir: string
+    let resolvedRunId: string
+    try {
+      const r = await resolveRunDir(programDir, run_id)
+      runDir = r.runDir
+      resolvedRunId = r.runId
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+
+    const summaryPath = join(runDir, "summary.md")
+    const hasSummary = await Bun.file(summaryPath).exists()
+
+    if (hasSummary) {
+      const summaryText = await Bun.file(summaryPath).text()
+      const state = await readState(runDir)
+      const stats = getRunStats(state, programConfig.direction)
+      return jsonText({
+        run_id: resolvedRunId,
+        has_summary: true,
+        generated: false,
+        summary: summaryText,
+        stats: {
+          total_experiments: stats.total_experiments,
+          total_keeps: stats.total_keeps,
+          improvement_pct: stats.improvement_pct,
+        },
+      })
+    }
+
+    if (generate) {
+      const state = await readState(runDir)
+      if (state.phase !== "complete" && state.phase !== "crashed") {
+        return errorResult("Can only generate summary for completed or crashed runs.")
+      }
+
+      const results = await readAllResults(runDir)
+      const summaryText = generateSummaryReport(state, results, programConfig, "")
+      await saveFinalizeReport(runDir, summaryText)
+
+      const stats = getRunStats(state, programConfig.direction)
+      return jsonText({
+        run_id: resolvedRunId,
+        has_summary: true,
+        generated: true,
+        summary: summaryText,
+        stats: {
+          total_experiments: stats.total_experiments,
+          total_keeps: stats.total_keeps,
+          improvement_pct: stats.improvement_pct,
+        },
+      })
+    }
+
+    return jsonText({
+      run_id: resolvedRunId,
+      has_summary: false,
+      generated: false,
+      summary: null,
+      stats: null,
+      hint: "Use generate=true to create a stats summary for completed runs.",
+    })
   },
 )
 

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -468,6 +468,17 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
                   } else if (final.state.phase === "complete") {
                     setPhase("complete")
                   } else {
+                    // Persist crashed state to disk so the run doesn't stay
+                    // stuck in a non-terminal phase after the TUI closes
+                    const crashedState: RunState = {
+                      ...final.state,
+                      phase: "crashed",
+                      error: logTail || "Daemon died unexpectedly",
+                      error_phase: final.state.phase,
+                      updated_at: new Date().toISOString(),
+                    }
+                    writeState(activeRunDir, crashedState).catch(() => {})
+                    setRunState(crashedState)
                     const detail = logTail ? `\n\n${logTail}` : ""
                     setLastError(`Daemon died unexpectedly while ${final.state.phase}${detail}`)
                     setPhase("error")

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -13,7 +13,7 @@ import { RunsTable } from "../components/RunsTable.tsx"
 import { formatShellError } from "../lib/git.ts"
 import { listDrafts, deleteDraft, type DraftSession, type DraftEntry } from "../lib/drafts.ts"
 import { readQueue, removeFromQueue, clearQueue, type QueueFile } from "../lib/queue.ts"
-import { abortAndDeleteActiveRuns } from "../lib/daemon-status.ts"
+import { abortAndDeleteActiveRuns, cleanupStaleRuns } from "../lib/daemon-status.ts"
 import { colors } from "../lib/theme.ts"
 
 interface HomeScreenProps {
@@ -63,6 +63,9 @@ async function loadHomeData(cwd: string): Promise<HomeData> {
         listRuns(programDir),
         loadProgramConfig(programDir).catch(() => null),
       ])
+
+      // Clean up runs whose daemon died while the TUI wasn't watching
+      await cleanupStaleRuns(programDir, runs)
 
       allRuns.push(...runs)
       if (config) programConfigs[p.name] = config


### PR DESCRIPTION
## Summary
- Adds a full MCP server (`autoauto mcp`) that exposes AutoAuto's program and run management via Model Context Protocol
- **Setup tools**: `get_setup_guide`, `create_program`, `update_program`, `delete_program`, `validate_measurement`
- **Run tools**: `start_run`, `get_run_status`, `get_run_results`, `get_experiment_log`, `get_run_summary`, `list_runs`, `stop_run`, `update_run_limit`
- **Read tools**: `list_programs`, `get_program`
- Slug validation on all tools to prevent path traversal
- Crash-state persistence restored for daemon error handling

## Test plan
- [ ] `autoauto mcp` starts and responds to MCP protocol on stdio
- [ ] Create a program via `create_program`, verify files on disk
- [ ] `validate_measurement` runs measure.sh and reports CV%
- [ ] `start_run` spawns daemon, `get_run_status` shows progress
- [ ] `stop_run` soft-stops, `stop_run --abort` hard-aborts
- [ ] `get_run_summary` returns/generates summary for completed runs
- [ ] Slug validation rejects `../../etc` style names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server and new CLI entry for remote program/run management.
  * Home screen now performs automatic stale-run cleanup during load.

* **Bug Fixes**
  * Improved crash handling: persisted run state captures daemon logs and marks runs as crashed.
  * Unified formatting for run durations and percentage changes across UI/CLI.

* **Tests**
  * Added end-to-end tests validating stale run cleanup.

* **Chores**
  * Added runtime dependencies for MCP and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->