### PR TITLE
feat(mcp): add agent sessions and config tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ TUI tool for autoresearch — autonomous experiment loops on any codebase.
 - `docs/patterns/metric-design.md` — Metric design, scoring approaches, variance handling, gaming defenses
 - `docs/patterns/failure-modes.md` — Failure modes, anti-patterns & safeguards from real implementations
 - `docs/patterns/loop-tuning.md` — Loop design, context packets, stopping criteria, model choice
+- `docs/mcp-server.md` — MCP server: tools, workflows, and client configuration
 - `references/articles/INDEX.md` — 30 indexed autoresearch articles for inspiration
 
 ## Stack

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ autoauto queue add <program>         # Enqueue a run
 
 See [CLI Reference](docs/cli.md) for full documentation of all commands and flags.
 
+### MCP Server
+
+AutoAuto also ships as an [MCP server](https://modelcontextprotocol.io/), letting you use it from any coding agent (Claude Code, Cursor, Windsurf, etc.) that supports MCP. The TUI is recommended for the best experience, but the MCP server gives your agent full access to create programs, start runs, monitor progress, and read results.
+
+```bash
+autoauto mcp  # stdio transport, spawned by your MCP client
+```
+
+See [MCP Server](docs/mcp-server.md) for setup and the full tool reference.
+
 ## How it works
 
 ### 1. Setup — define what to optimize
@@ -207,6 +217,7 @@ Supported providers: **Claude** (Agent SDK), **Codex** (CLI), **OpenCode**.
 | Doc | Contents |
 |-----|----------|
 | [CLI Reference](docs/cli.md) | Full headless CLI documentation — all commands, flags, JSON output |
+| [MCP Server](docs/mcp-server.md) | MCP server setup, tools, and workflows for coding agent integration |
 | [Concepts](docs/concepts.md) | How AutoAuto works: programs, runs, experiments, measurement, agents |
 | [Glossary](docs/glossary.md) | Quick definitions for AutoAuto terms and run mechanics |
 | [Measurement Guide](docs/measurement-guide.md) | Writing good measurement scripts, choosing metrics, avoiding pitfalls |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,442 @@
+# MCP Server
+
+AutoAuto exposes a [Model Context Protocol](https://modelcontextprotocol.io/) server so coding agents can create, configure, run, and monitor autoresearch programs without using the TUI or CLI.
+
+## Starting the server
+
+```bash
+autoauto mcp                    # uses current directory
+autoauto mcp --cwd /path/to/project  # explicit project root
+```
+
+The server uses **stdio transport** — it reads/writes JSON-RPC on stdin/stdout and logs to stderr. MCP clients (Claude Code, Cursor, etc.) spawn it as a subprocess.
+
+### Client configuration
+
+Add to your MCP client config (e.g. `.mcp.json`, Claude Code settings, etc.):
+
+```json
+{
+  "mcpServers": {
+    "autoauto": {
+      "command": "autoauto",
+      "args": ["mcp", "--cwd", "/path/to/project"]
+    }
+  }
+}
+```
+
+## Tools
+
+The server exposes 25 tools organized into five categories.
+
+### Configuration & auth
+
+| Tool | Description |
+|------|-------------|
+| `get_config` | Get project config (models, providers, notifications) |
+| `set_config` | Update project config fields (only provided fields change) |
+| `list_models` | List available models per provider with defaults |
+| `check_auth` | Check authentication status for providers |
+
+### Program management
+
+| Tool | Description |
+|------|-------------|
+| `list_programs` | List all programs with goals and run counts |
+| `get_program` | Get full program details (config, program.md, scripts) |
+| `get_setup_guide` | Comprehensive guide for creating programs — read before `create_program` |
+| `create_program` | Create a new program with all files |
+| `update_program` | Update specific files in an existing program |
+| `delete_program` | Permanently delete a program and all runs (requires `confirm=true`) |
+
+### Agent sessions
+
+Interactive setup and update conversations powered by a support-model agent.
+
+| Tool | Description |
+|------|-------------|
+| `start_setup_session` | Start a setup conversation (`direct` or `analyze` mode) |
+| `start_update_session` | Start an update conversation for an existing program (auto-seeds with last run context) |
+| `send_session_message` | Send a user message and get the agent's reply |
+| `get_session` | Get transcript and metadata for a session |
+| `list_sessions` | List all persisted sessions |
+| `delete_session` | Delete a session (requires `confirm=true`) |
+
+### Run management
+
+| Tool | Description |
+|------|-------------|
+| `start_run` | Start an experiment run (spawns background daemon) |
+| `get_run_status` | Check run progress: phase, metrics, cost, daemon health |
+| `list_runs` | List all runs for a program (newest first) |
+| `get_run_results` | Get experiment results table (status, metric, change%, commit, description) |
+| `get_experiment_log` | Get agent streaming output for a specific experiment |
+| `stop_run` | Stop active run — soft stop (default) or hard abort |
+| `update_run_limit` | Change max experiments cap mid-run |
+
+### Post-run analysis
+
+| Tool | Description |
+|------|-------------|
+| `get_run_summary` | Get or generate a summary report for a completed run |
+| `validate_measurement` | Run measurement script multiple times, report CV% and stability assessment |
+
+## Workflows
+
+### Creating a program
+
+1. `get_setup_guide` — learn artifact formats and best practices
+2. `list_programs` — check for duplicates
+3. `create_program` — write program.md, measure.sh, config.json, and optionally build.sh
+4. `validate_measurement` — verify measurement stability (aim for CV <5%)
+
+### Running experiments
+
+1. `start_run` — spawns a background daemon that measures baseline then runs experiments autonomously
+2. `get_run_status` — poll for progress (phase, metrics, keep rate, cost)
+3. `get_run_results` — inspect individual experiment outcomes
+4. `get_experiment_log` — read agent output for a specific experiment
+5. `stop_run` — stop when satisfied (or let it hit the max experiments cap)
+6. `get_run_summary` — get the final report (use `generate=true` if none exists)
+
+### Updating a program after a run
+
+1. `start_update_session` — begins a conversation pre-seeded with the latest run's results
+2. `send_session_message` — iterate on the program definition with the agent
+3. `update_program` — apply changes to specific files
+4. `validate_measurement` — re-check if you changed measure.sh or config
+
+## Tool reference
+
+### get_config
+
+Returns the full project configuration.
+
+**Input:** none
+
+**Output:** JSON with `executionModel`, `supportModel`, `executionFallbackModel`, `ideasBacklogEnabled`, `notificationPreset`, `notificationCommand`.
+
+---
+
+### set_config
+
+Update project configuration. Only provided fields are changed.
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `executionModel` | `{provider, model, effort}` | Experiment agent model slot |
+| `supportModel` | `{provider, model, effort}` | Setup/finalize agent model slot |
+| `executionFallbackModel` | `{provider, model, effort} \| null` | Fallback model (null to clear) |
+| `ideasBacklogEnabled` | boolean | Enable/disable ideas backlog |
+| `notificationPreset` | string | `off`, `macos-notification`, `macos-say`, `terminal-bell`, `custom` |
+| `notificationCommand` | string \| null | Custom notification command |
+
+---
+
+### list_models
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider` | string? | Filter to one provider (`claude`, `codex`, `opencode`) |
+| `force_refresh` | boolean | Ask provider to refresh model data (default false) |
+
+**Output:** Per-provider list of models with `label`, `description`, `is_default`, and the provider's `default_model`.
+
+---
+
+### check_auth
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider` | string? | Filter to one provider |
+
+**Output:** Per-provider `authenticated`, `error`, `account`.
+
+---
+
+### list_programs
+
+**Input:** none
+
+**Output:** Array of `{name, goal, totalRuns, hasActiveRun}`.
+
+---
+
+### get_program
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+
+**Output:** `{name, config, program_md, measure_sh, build_sh}`.
+
+---
+
+### get_setup_guide
+
+**Input:** none
+
+**Output:** Markdown guide covering artifact formats, measurement requirements, quality gate design, and anti-gaming rules.
+
+---
+
+### create_program
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug (lowercase, numbers, hyphens) |
+| `program_md` | string | Full contents of program.md |
+| `measure_sh` | string | Full contents of measure.sh |
+| `build_sh` | string? | Full contents of build.sh (optional) |
+| `config` | object | Program config (see below) |
+
+**Config object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `metric_field` | string | Key in measure.sh JSON output to optimize |
+| `direction` | `lower` \| `higher` | Which direction is better |
+| `noise_threshold` | number | Minimum relative improvement to keep (0.02 = 2%) |
+| `repeats` | integer | Measurements per experiment |
+| `max_experiments` | integer | Cap per run |
+| `quality_gates` | object? | `{field: {min?, max?}}` — hard pass/fail constraints |
+| `secondary_metrics` | object? | `{field: {direction}}` — advisory metrics |
+| `max_consecutive_discards` | integer? | Auto-stop after N consecutive non-improving experiments |
+| `measurement_timeout` | integer? | Timeout in ms for measure.sh (default 60000) |
+| `build_timeout` | integer? | Timeout in ms for build.sh (default 600000) |
+| `max_cost_usd` | number? | Cost cap per run in USD |
+| `max_turns` | integer? | Max agent turns per experiment |
+| `keep_simplifications` | boolean? | Keep experiments that simplify code without improving metric |
+| `finalize_risk_assessment` | boolean? | Run risk assessment during finalization |
+
+Fails if the program slug already exists. Call `validate_measurement` after creating.
+
+---
+
+### update_program
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `program_md` | string? | New program.md contents |
+| `measure_sh` | string? | New measure.sh contents |
+| `build_sh` | string? | New build.sh contents |
+| `config` | object? | New config.json contents |
+
+Only provided fields are overwritten.
+
+---
+
+### delete_program
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `confirm` | `true` | Must be `true` to confirm |
+
+Refuses to delete programs with active runs.
+
+---
+
+### validate_measurement
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `runs` | integer | Number of measurement runs (1-20, default 5) |
+
+Creates a temporary git worktree, runs build.sh + measure.sh multiple times, and reports:
+- **CV%** — coefficient of variation
+- **Assessment** — `deterministic` (<1%), `excellent` (1-5%), `acceptable` (5-15%), `noisy` (15-30%), `unstable` (>30%)
+- **Recommended config** — suggested `noise_threshold` and `repeats` values
+
+---
+
+### start_setup_session
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | `direct` \| `analyze` | `analyze` for ideation, `direct` when you know the target |
+| `message` | string? | Optional first message (direct mode) |
+| `focus` | string? | Area to focus on (analyze mode) |
+| `provider` | string? | Support-model provider override |
+| `model` | string? | Support-model name override |
+| `effort` | string? | Support-model effort override |
+
+**Output:** `{session_id, kind, provider, model, effort, assistant_message, tool_events, messages}`.
+
+---
+
+### start_update_session
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `provider` | string? | Support-model provider override |
+| `model` | string? | Support-model name override |
+| `effort` | string? | Support-model effort override |
+
+Auto-seeds the agent with the latest run's context (results, summary, metrics).
+
+---
+
+### send_session_message
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | string | Session ID |
+| `message` | string | User message |
+
+**Output:** `{session_id, assistant_message, tool_events, messages}`.
+
+---
+
+### get_session
+
+**Input:** `session_id`
+
+**Output:** Full session metadata and message transcript.
+
+---
+
+### list_sessions
+
+**Input:** none
+
+**Output:** Array of session summaries with `session_id`, `kind`, `program_slug`, `updated_at`, `message_count`.
+
+---
+
+### delete_session
+
+**Input:** `session_id`, `confirm=true`
+
+---
+
+### start_run
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `provider` | string? | Agent provider (default: from project config) |
+| `model` | string? | Model name (default: from project config) |
+| `effort` | string? | Effort level (default: from project config) |
+| `max_experiments` | integer? | Override max experiments |
+| `use_worktree` | boolean | Use git worktree isolation (default true) |
+| `carry_forward` | boolean | Carry forward context from previous runs (default true) |
+
+**Output:** `{run_id, daemon_pid, status}`. The daemon runs in the background — use `get_run_status` to poll.
+
+---
+
+### get_run_status
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `run_id` | string? | Specific run ID (default: latest) |
+
+**Output:** `{run_id, phase, daemon_alive, experiment_number, metric_field, direction, original_baseline, current_baseline, best_metric, improvement, keeps, discards, crashes, keep_rate, cost_usd, elapsed, model, provider, termination_reason, error}`.
+
+---
+
+### list_runs
+
+**Input:** `name`
+
+**Output:** Array of `{run_id, phase, experiments, best_metric, change}` (newest first).
+
+---
+
+### get_run_results
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `run_id` | string? | Specific run ID (default: latest) |
+| `limit` | integer? | Return only the last N results |
+
+**Output:** `{run_id, metric_field, direction, total_results, results: [{experiment_number, status, metric_value, change, commit, description, diff_stats}]}`.
+
+---
+
+### get_experiment_log
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `experiment_number` | integer \| `"latest"` | Experiment number (0 = baseline) or `"latest"` |
+| `run_id` | string? | Specific run ID (default: latest) |
+
+**Output:** Raw agent streaming output (thinking, tool use, code changes).
+
+---
+
+### stop_run
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `abort` | boolean | Hard abort (default: false = soft stop) |
+
+Soft stop waits for the current experiment to finish. Hard abort kills the agent immediately and records the experiment as a crash.
+
+---
+
+### update_run_limit
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `max_experiments` | integer | New max experiments value |
+
+Takes effect at the next experiment boundary.
+
+---
+
+### get_run_summary
+
+**Input:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Program slug |
+| `run_id` | string? | Specific run ID (default: latest) |
+| `generate` | boolean | Generate stats summary if none exists (default false) |
+
+Returns the existing summary if available. With `generate=true`, creates a stats-based summary for completed or crashed runs.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,4 @@
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
+import { join } from "node:path"
 import {
   listPrograms,
   loadProgramConfig,
@@ -54,6 +53,8 @@ import {
   clearQueue,
   startNextFromQueue,
 } from "./lib/queue.ts"
+import { getSelfCommand } from "./lib/self-command.ts"
+import { AUTOAUTO_VERSION } from "./version.ts"
 
 // --- Arg Parsing ---
 
@@ -1558,9 +1559,8 @@ async function cmdValidate(args: ParsedArgs) {
     measurePath = fallback
   }
 
-  const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "lib", "validate-measurement.ts")
-
-  const proc = Bun.spawn(["bun", "run", scriptPath, measurePath, configPath, String(numRuns)], {
+  const validator = getSelfCommand("__validate_measurement")
+  const proc = Bun.spawn([validator.command, ...validator.args, measurePath, configPath, String(numRuns)], {
     stdout: "pipe",
     stderr: "inherit",
   })
@@ -1702,9 +1702,20 @@ const COMMANDS: Record<string, (args: ParsedArgs) => Promise<void>> = {
 }
 
 export async function run(argv: string[]) {
+  if (argv[0] === "__daemon") {
+    const { startDaemon } = await import("./daemon.ts")
+    await startDaemon(argv.slice(1))
+    return
+  }
+
+  if (argv[0] === "__validate_measurement") {
+    const { startValidateMeasurement } = await import("./lib/validate-measurement.ts")
+    await startValidateMeasurement(argv.slice(1))
+    return
+  }
+
   if (argv.includes("--version") || argv.includes("-v")) {
-    const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json()
-    out(pkg.version)
+    out(AUTOAUTO_VERSION)
     return
   }
 

--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -28,11 +28,6 @@ function ExperimentDetail({ result, secondaryMetrics }: {
   return (
     <box flexDirection="column" paddingX={1} gap={1}>
       <box flexDirection="column">
-        <text selectable><strong fg={colors.text}>Experiment #{result.experiment_number}</strong></text>
-        <text fg={colors.textDim}>{"─".repeat(40)}</text>
-      </box>
-
-      <box flexDirection="column">
         <text selectable><strong fg={colors.text}>Status:  </strong><strong fg={statusColor(result.status)}>{result.status}</strong></text>
         <text selectable><strong fg={colors.text}>Commit:  </strong><strong fg={colors.text}>{result.commit}</strong></text>
         <text selectable><strong fg={colors.text}>Metric:  </strong><strong fg={colors.text}>{result.metric_value ?? "—"}</strong></text>

--- a/src/components/CycleField.tsx
+++ b/src/components/CycleField.tsx
@@ -3,18 +3,19 @@ import { colors } from "../lib/theme.ts"
 interface CycleFieldProps {
   label: string
   value: string
+  hint?: string
   description?: string
   isFocused: boolean
 }
 
-export function CycleField({ label, value, description, isFocused }: CycleFieldProps) {
+export function CycleField({ label, value, hint, description, isFocused }: CycleFieldProps) {
   return (
     <box flexDirection="column">
       <text>
         {isFocused ? (
-          <span fg={colors.primary}><strong>{`  ${label}: \u25C2 ${value} \u25B8`}</strong></span>
+          <><span fg={colors.primary}><strong>{`  ${label}: \u25C2 ${value} \u25B8`}</strong></span>{hint && <span fg={colors.textDim}>{` ${hint}`}</span>}</>
         ) : (
-          `  ${label}: ${value}`
+          <>{`  ${label}: ${value}`}{hint && <span fg={colors.textDim}>{` ${hint}`}</span>}</>
         )}
       </text>
       {isFocused && description && (

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -38,8 +38,7 @@ import { removeWorktree } from "./lib/worktree.ts"
 
 // --- Parse CLI args ---
 
-function parseArgs(): { programSlug: string; runId: string; mainRoot: string; worktreePath: string; daemonId: string; inPlace: boolean } {
-  const args = process.argv.slice(2)
+function parseArgs(args: string[]): { programSlug: string; runId: string; mainRoot: string; worktreePath: string; daemonId: string; inPlace: boolean } {
   const inPlace = args.includes("--in-place")
   // Remove --in-place before key-value parsing (it's a boolean flag)
   const kvArgs = args.filter((a) => a !== "--in-place")
@@ -67,9 +66,9 @@ function parseArgs(): { programSlug: string; runId: string; mainRoot: string; wo
 
 // --- Main ---
 
-async function main() {
+export async function startDaemon(args = process.argv.slice(2)) {
   registerDefaultProviders()
-  const { programSlug, runId, mainRoot, worktreePath, daemonId, inPlace } = parseArgs()
+  const { programSlug, runId, mainRoot, worktreePath, daemonId, inPlace } = parseArgs(args)
   const programDir = join(mainRoot, ".autoauto", "programs", programSlug)
   const runDir = join(programDir, "runs", runId)
 
@@ -351,7 +350,9 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  process.stderr.write(`Daemon fatal error: ${formatShellError(err)}\n`)
-  process.exit(1)
-})
+if (import.meta.main) {
+  startDaemon().catch((err) => {
+    process.stderr.write(`Daemon fatal error: ${formatShellError(err)}\n`)
+    process.exit(1)
+  })
+}

--- a/src/e2e/finalize.e2e.test.ts
+++ b/src/e2e/finalize.e2e.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect, afterEach } from "bun:test"
+import { createTestFixture, type TestFixture } from "./fixture.ts"
+import { buildFinalizeContext, buildFinalizeInitialMessage } from "../lib/finalize.ts"
+import { loadProgramConfig } from "../lib/programs.ts"
+import type { RunState } from "../lib/run.ts"
+import { join } from "node:path"
+
+describe("finalize with removed worktree", () => {
+  let fixture: TestFixture
+
+  afterEach(async () => {
+    await fixture?.cleanup()
+  })
+
+  test("buildFinalizeContext succeeds when worktree is gone and headRef is branch name", async () => {
+    fixture = await createTestFixture()
+    const programDir = await fixture.createProgram("perf", {
+      metric_field: "score",
+      direction: "lower",
+    })
+    const runDir = await fixture.createRun("perf", {
+      run_id: "20260412-190000",
+      phase: "complete",
+      experiment_number: 2,
+      best_metric: 90,
+      best_experiment: 1,
+      total_keeps: 1,
+      total_discards: 1,
+      createGitBranch: true,
+      commitCount: 2,
+      results: [
+        { experiment_number: 1, commit: "aaa1111", metric_value: 90, status: "keep", description: "opt 1" },
+        { experiment_number: 2, commit: "bbb2222", metric_value: 105, status: "discard", description: "opt 2" },
+      ],
+    })
+
+    const config = await loadProgramConfig(programDir)
+    const state: RunState = await Bun.file(join(runDir, "state.json")).json()
+
+    // Simulate worktree being removed: use the main checkout (fixture.cwd)
+    // and pass the branch name as headRef instead of "HEAD"
+    const context = await buildFinalizeContext(
+      fixture.cwd,
+      runDir,
+      state,
+      config,
+      fixture.cwd,
+      state.branch_name,
+    )
+
+    expect(context.changedFiles.length).toBeGreaterThan(0)
+    expect(context.results.length).toBe(2)
+
+    const message = await buildFinalizeInitialMessage(context, state.branch_name)
+    expect(message).toContain("perf")
+    expect(message).toContain("Changed Files")
+    expect(message).toContain("Full Diff")
+    // The diff should show actual experiment commits, not be empty
+    expect(message).not.toContain("```diff\n\n```")
+  })
+
+  test("buildFinalizeContext fails when worktree path does not exist and HEAD is used", async () => {
+    fixture = await createTestFixture()
+    const programDir = await fixture.createProgram("perf", {
+      metric_field: "score",
+      direction: "lower",
+    })
+    const runDir = await fixture.createRun("perf", {
+      run_id: "20260412-190001",
+      phase: "complete",
+      experiment_number: 1,
+      best_metric: 90,
+      best_experiment: 1,
+      total_keeps: 1,
+      createGitBranch: true,
+      commitCount: 1,
+      results: [
+        { experiment_number: 1, commit: "aaa1111", metric_value: 90, status: "keep", description: "opt 1" },
+      ],
+    })
+
+    const config = await loadProgramConfig(programDir)
+    const state: RunState = await Bun.file(join(runDir, "state.json")).json()
+
+    // Using a nonexistent worktree path should fail
+    const fakeWorktreePath = join(fixture.cwd, ".autoauto", "worktrees", "gone")
+    await expect(
+      buildFinalizeContext(fakeWorktreePath, runDir, state, config),
+    ).rejects.toThrow()
+  })
+})

--- a/src/e2e/home-queue.e2e.test.tsx
+++ b/src/e2e/home-queue.e2e.test.tsx
@@ -34,7 +34,7 @@ afterAll(async () => {
   await fixture.cleanup()
 })
 
-function renderHome() {
+function renderHome(onResumeQueue = noop) {
   return renderTui(
     <HomeScreen
       cwd={fixture.cwd}
@@ -44,6 +44,7 @@ function renderHome() {
       onUpdateProgram={noop}
       onFinalizeRun={noop}
       onResumeDraft={noop}
+      onResumeQueue={onResumeQueue}
     />,
     { width: 120 },
   )
@@ -116,6 +117,16 @@ describe("HomeScreen — queue panel", () => {
     // Queue should still be there
     const frame = await harness.flush()
     expect(frame).toContain("Queue (2)")
+  })
+
+  test("s on queue panel resumes the queue", async () => {
+    let resumed = 0
+    harness = await renderHome(() => { resumed++ })
+    await harness.waitForText("Queue (2)")
+    await harness.tab()
+    await harness.tab()
+    await harness.press("s")
+    expect(resumed).toBe(1)
   })
 })
 

--- a/src/e2e/mcp-daemon.e2e.test.ts
+++ b/src/e2e/mcp-daemon.e2e.test.ts
@@ -1,0 +1,288 @@
+/**
+ * E2E tests for MCP daemon tools (start_run, stop_run, update_run_limit).
+ * These tools interact with daemon processes, so we mock the daemon-client
+ * module. Everything else (MCP protocol, filesystem, programs) is real.
+ *
+ * Separated from mcp-server.e2e.test.ts so the module mock doesn't pollute
+ * the zero-mocking filesystem tests.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock, type Mock } from "bun:test"
+import { createTestFixture, type TestFixture } from "./fixture.ts"
+import { createProgramForMcp, createRunForMcp, getTextContent, getJsonContent, type McpTestContext } from "./mcp-helpers.ts"
+
+// ---------------------------------------------------------------------------
+// Mock daemon modules BEFORE importing createMcpServer
+// ---------------------------------------------------------------------------
+
+const mockSpawnDaemon = mock(() =>
+  Promise.resolve({ runId: "20260412-100000", runDir: "/tmp/fake", worktreePath: null, pid: 99999 }),
+)
+const mockFindActiveRun = mock(() => Promise.resolve(null)) as Mock<() => Promise<{
+  runId: string
+  runDir: string
+  daemonAlive: boolean
+} | null>>
+const mockSendStop = mock(() => Promise.resolve())
+const mockSendAbort = mock(() => Promise.resolve())
+const mockForceKillDaemon = mock(() => Promise.resolve())
+const mockGetDaemonStatus = mock(() => Promise.resolve({ alive: false, starting: false, daemonJson: null }))
+const mockUpdateMaxExperiments = mock(() => Promise.resolve())
+
+mock.module("../lib/daemon-spawn.ts", () => ({
+  spawnDaemon: mockSpawnDaemon,
+}))
+
+mock.module("../lib/daemon-status.ts", () => ({
+  getDaemonStatus: mockGetDaemonStatus,
+  sendStop: mockSendStop,
+  sendAbort: mockSendAbort,
+  forceKillDaemon: mockForceKillDaemon,
+  updateMaxExperiments: mockUpdateMaxExperiments,
+  findActiveRun: mockFindActiveRun,
+  reconstructState: mock(() => Promise.resolve(null)),
+  getMaxExperiments: mock(() => Promise.resolve(null)),
+  readDaemonLogTail: mock(() => Promise.resolve("")),
+  getMaxCostUsd: mock(() => Promise.resolve(null)),
+  updateMaxCostUsd: mock(() => Promise.resolve()),
+}))
+
+// Import AFTER mocks are set up — can't reuse createMcpTestClient from helpers
+// because that would import createMcpServer before mock.module takes effect.
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import { createMcpServer } from "../mcp.ts"
+import { resetProjectRoot } from "../lib/programs.ts"
+
+async function createMcpClient(cwd: string): Promise<McpTestContext> {
+  resetProjectRoot()
+  const server = createMcpServer(cwd)
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: "test-client", version: "1.0.0" })
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+  return {
+    client,
+    cleanup: async () => {
+      await client.close()
+      await server.close()
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// start_run
+// ---------------------------------------------------------------------------
+
+describe("MCP start_run", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpClient(fixture.cwd)
+    mockSpawnDaemon.mockClear()
+    mockSpawnDaemon.mockImplementation(() =>
+      Promise.resolve({ runId: "20260412-100000", runDir: "/tmp/fake", worktreePath: null, pid: 99999 }),
+    )
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("starts a run and returns run info", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+
+    const result = await mcp.client.callTool({
+      name: "start_run",
+      arguments: { name: "test-prog" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as { run_id: string; daemon_pid: number; status: string }
+    expect(data.run_id).toBe("20260412-100000")
+    expect(data.daemon_pid).toBe(99999)
+    expect(data.status).toBe("started")
+    expect(mockSpawnDaemon).toHaveBeenCalledTimes(1)
+  })
+
+  test("passes custom model and max_experiments to daemon", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+
+    await mcp.client.callTool({
+      name: "start_run",
+      arguments: {
+        name: "test-prog",
+        provider: "codex",
+        model: "o3",
+        effort: "max",
+        max_experiments: 50,
+      },
+    })
+
+    expect(mockSpawnDaemon).toHaveBeenCalledTimes(1)
+    const args = mockSpawnDaemon.mock.calls[0]
+    expect(args[2]).toEqual({ provider: "codex", model: "o3", effort: "max" })
+    expect(args[3]).toBe(50)
+  })
+
+  test("returns error for non-existent program", async () => {
+    const result = await mcp.client.callTool({
+      name: "start_run",
+      arguments: { name: "no-such" },
+    })
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("not found")
+    expect(mockSpawnDaemon).not.toHaveBeenCalled()
+  })
+
+  test("returns error when daemon spawn fails", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    mockSpawnDaemon.mockImplementation(() => Promise.reject(new Error("Working tree is dirty")))
+
+    const result = await mcp.client.callTool({
+      name: "start_run",
+      arguments: { name: "test-prog" },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("dirty")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stop_run
+// ---------------------------------------------------------------------------
+
+describe("MCP stop_run", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpClient(fixture.cwd)
+    mockFindActiveRun.mockClear()
+    mockSendStop.mockClear()
+    mockSendAbort.mockClear()
+    mockForceKillDaemon.mockClear()
+    mockGetDaemonStatus.mockClear()
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("sends soft stop signal", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", { phase: "agent_running" })
+
+    mockFindActiveRun.mockImplementation(() =>
+      Promise.resolve({ runId: "20260412-100000", runDir, daemonAlive: true }),
+    )
+
+    const result = await mcp.client.callTool({
+      name: "stop_run",
+      arguments: { name: "test-prog" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as { action: string; status: string }
+    expect(data.action).toBe("stop")
+    expect(data.status).toBe("stopping")
+    expect(mockSendStop).toHaveBeenCalledTimes(1)
+  })
+
+  test("sends abort signal with abort=true", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", { phase: "agent_running" })
+
+    mockFindActiveRun.mockImplementation(() =>
+      Promise.resolve({ runId: "20260412-100000", runDir, daemonAlive: true }),
+    )
+    // getDaemonStatus returns not alive after abort
+    mockGetDaemonStatus.mockImplementation(() =>
+      Promise.resolve({ alive: false, starting: false, daemonJson: null }),
+    )
+
+    const result = await mcp.client.callTool({
+      name: "stop_run",
+      arguments: { name: "test-prog", abort: true },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as { action: string; status: string }
+    expect(data.action).toBe("abort")
+    expect(data.status).toBe("aborted")
+    expect(mockSendAbort).toHaveBeenCalledTimes(1)
+  })
+
+  test("returns error when no active run", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    mockFindActiveRun.mockImplementation(() => Promise.resolve(null))
+
+    const result = await mcp.client.callTool({
+      name: "stop_run",
+      arguments: { name: "test-prog" },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("No active run")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// update_run_limit
+// ---------------------------------------------------------------------------
+
+describe("MCP update_run_limit", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpClient(fixture.cwd)
+    mockFindActiveRun.mockClear()
+    mockUpdateMaxExperiments.mockClear()
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("updates max experiments on active run", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", { phase: "agent_running" })
+
+    mockFindActiveRun.mockImplementation(() =>
+      Promise.resolve({ runId: "20260412-100000", runDir, daemonAlive: true }),
+    )
+
+    const result = await mcp.client.callTool({
+      name: "update_run_limit",
+      arguments: { name: "test-prog", max_experiments: 100 },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as { run_id: string; max_experiments: number }
+    expect(data.max_experiments).toBe(100)
+    expect(mockUpdateMaxExperiments).toHaveBeenCalledTimes(1)
+    expect(mockUpdateMaxExperiments.mock.calls[0][1]).toBe(100)
+  })
+
+  test("returns error when no active run", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    mockFindActiveRun.mockImplementation(() => Promise.resolve(null))
+
+    const result = await mcp.client.callTool({
+      name: "update_run_limit",
+      arguments: { name: "test-prog", max_experiments: 50 },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("No active run")
+  })
+})

--- a/src/e2e/mcp-daemon.e2e.test.ts
+++ b/src/e2e/mcp-daemon.e2e.test.ts
@@ -286,6 +286,7 @@ describe("MCP update_run_limit", () => {
     const data = getJsonContent(result) as { run_id: string; max_experiments: number }
     expect(data.max_experiments).toBe(100)
     expect(mockUpdateMaxExperiments).toHaveBeenCalledTimes(1)
+    expect(mockUpdateMaxExperiments.mock.calls[0][0]).toBe(runDir)
     expect(mockUpdateMaxExperiments.mock.calls[0][1]).toBe(100)
   })
 

--- a/src/e2e/mcp-daemon.e2e.test.ts
+++ b/src/e2e/mcp-daemon.e2e.test.ts
@@ -128,6 +128,34 @@ describe("MCP start_run", () => {
     expect(args[3]).toBe(50)
   })
 
+  test("allows start_run immediately after create_program adds .autoauto to .gitignore", async () => {
+    const created = await mcp.client.callTool({
+      name: "create_program",
+      arguments: {
+        name: "fresh-prog",
+        program_md: "# Fresh Program\n\n## Goal\nKeep score low.\n",
+        measure_sh: '#!/bin/bash\necho \'{"score": 1}\'',
+        config: {
+          metric_field: "score",
+          direction: "lower",
+          noise_threshold: 0.01,
+          repeats: 1,
+          max_experiments: 5,
+          quality_gates: {},
+        },
+      },
+    })
+    expect(created.isError).toBeFalsy()
+
+    const result = await mcp.client.callTool({
+      name: "start_run",
+      arguments: { name: "fresh-prog" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(mockSpawnDaemon).toHaveBeenCalledTimes(1)
+  })
+
   test("returns error for non-existent program", async () => {
     const result = await mcp.client.callTool({
       name: "start_run",

--- a/src/e2e/mcp-daemon.e2e.test.ts
+++ b/src/e2e/mcp-daemon.e2e.test.ts
@@ -1,18 +1,21 @@
 /**
  * E2E tests for MCP daemon tools (start_run, stop_run, update_run_limit).
- * These tools interact with daemon processes, so we mock the daemon-client
- * module. Everything else (MCP protocol, filesystem, programs) is real.
- *
- * Separated from mcp-server.e2e.test.ts so the module mock doesn't pollute
- * the zero-mocking filesystem tests.
+ * These tools interact with daemon processes, so we inject mock daemon
+ * dependencies via createMcpServer's daemonDeps parameter instead of using
+ * mock.module (which is process-wide in Bun and causes segfaults when
+ * combined with OpenTUI test renderer).
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock, type Mock } from "bun:test"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
 import { createTestFixture, type TestFixture } from "./fixture.ts"
 import { createProgramForMcp, createRunForMcp, getTextContent, getJsonContent, type McpTestContext } from "./mcp-helpers.ts"
+import { createMcpServer, type McpDaemonDeps } from "../mcp.ts"
+import { resetProjectRoot } from "../lib/programs.ts"
 
 // ---------------------------------------------------------------------------
-// Mock daemon modules BEFORE importing createMcpServer
+// Mock daemon functions — injected via createMcpServer's daemonDeps
 // ---------------------------------------------------------------------------
 
 const mockSpawnDaemon = mock(() =>
@@ -29,34 +32,19 @@ const mockForceKillDaemon = mock(() => Promise.resolve())
 const mockGetDaemonStatus = mock(() => Promise.resolve({ alive: false, starting: false, daemonJson: null }))
 const mockUpdateMaxExperiments = mock(() => Promise.resolve())
 
-mock.module("../lib/daemon-spawn.ts", () => ({
+const daemonDeps: Partial<McpDaemonDeps> = {
   spawnDaemon: mockSpawnDaemon,
-}))
-
-mock.module("../lib/daemon-status.ts", () => ({
   getDaemonStatus: mockGetDaemonStatus,
   sendStop: mockSendStop,
   sendAbort: mockSendAbort,
   forceKillDaemon: mockForceKillDaemon,
-  updateMaxExperiments: mockUpdateMaxExperiments,
   findActiveRun: mockFindActiveRun,
-  reconstructState: mock(() => Promise.resolve(null)),
-  getMaxExperiments: mock(() => Promise.resolve(null)),
-  readDaemonLogTail: mock(() => Promise.resolve("")),
-  getMaxCostUsd: mock(() => Promise.resolve(null)),
-  updateMaxCostUsd: mock(() => Promise.resolve()),
-}))
-
-// Import AFTER mocks are set up — can't reuse createMcpTestClient from helpers
-// because that would import createMcpServer before mock.module takes effect.
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
-import { createMcpServer } from "../mcp.ts"
-import { resetProjectRoot } from "../lib/programs.ts"
+  updateMaxExperiments: mockUpdateMaxExperiments,
+}
 
 async function createMcpClient(cwd: string): Promise<McpTestContext> {
   resetProjectRoot()
-  const server = createMcpServer(cwd)
+  const server = createMcpServer(cwd, daemonDeps)
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
   const client = new Client({ name: "test-client", version: "1.0.0" })
   await server.connect(serverTransport)

--- a/src/e2e/mcp-helpers.ts
+++ b/src/e2e/mcp-helpers.ts
@@ -1,0 +1,168 @@
+/**
+ * MCP E2E test helpers: connects a real MCP Client to the AutoAuto MCP Server
+ * via in-memory transport for true end-to-end protocol testing.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import { createMcpServer } from "../mcp.ts"
+import { join } from "node:path"
+import { mkdir, chmod } from "node:fs/promises"
+import { resetProjectRoot } from "../lib/programs.ts"
+
+export interface McpTestContext {
+  client: Client
+  cleanup: () => Promise<void>
+}
+
+/** Create an MCP Client connected to the real MCP Server via in-memory transport. */
+export async function createMcpTestClient(cwd: string): Promise<McpTestContext> {
+  resetProjectRoot()
+  const server = createMcpServer(cwd)
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+  const client = new Client({ name: "test-client", version: "1.0.0" })
+
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close()
+      await server.close()
+    },
+  }
+}
+
+/** Extract text content from an MCP CallToolResult. */
+export function getTextContent(result: { content: Array<{ type: string; text?: string }> }): string {
+  const item = result.content.find((c) => c.type === "text")
+  return item?.text ?? ""
+}
+
+/** Parse JSON from an MCP CallToolResult text content. */
+export function getJsonContent(result: { content: Array<{ type: string; text?: string }> }): unknown {
+  return JSON.parse(getTextContent(result))
+}
+
+export interface McpProgramOpts {
+  config?: {
+    metric_field?: string
+    direction?: "lower" | "higher"
+    noise_threshold?: number
+    repeats?: number
+    max_experiments?: number
+    quality_gates?: Record<string, { min?: number; max?: number }>
+  }
+  programMd?: string
+  measureSh?: string
+  buildSh?: string
+}
+
+/**
+ * Create a program directory with the file layout the MCP server expects
+ * (measure.sh, program.md, config.json). Unlike the TUI fixture which writes
+ * `measure`, the MCP server expects `measure.sh`.
+ */
+export async function createProgramForMcp(
+  cwd: string,
+  slug: string,
+  opts: McpProgramOpts = {},
+): Promise<string> {
+  const programDir = join(cwd, ".autoauto", "programs", slug)
+  await mkdir(programDir, { recursive: true })
+
+  const config = {
+    metric_field: opts.config?.metric_field ?? "score",
+    direction: opts.config?.direction ?? "lower",
+    noise_threshold: opts.config?.noise_threshold ?? 0.02,
+    repeats: opts.config?.repeats ?? 1,
+    max_experiments: opts.config?.max_experiments ?? 10,
+    quality_gates: opts.config?.quality_gates ?? {},
+  }
+
+  const measureSh = opts.measureSh ?? '#!/bin/bash\necho \'{"score": 42}\''
+  const programMd = opts.programMd ?? "# Test Program\n\n## Goal\nOptimize the score.\n"
+
+  await Promise.all([
+    Bun.write(join(programDir, "config.json"), JSON.stringify(config, null, 2) + "\n"),
+    Bun.write(join(programDir, "measure.sh"), measureSh),
+    Bun.write(join(programDir, "program.md"), programMd),
+    ...(opts.buildSh ? [Bun.write(join(programDir, "build.sh"), opts.buildSh)] : []),
+  ])
+
+  await chmod(join(programDir, "measure.sh"), 0o755)
+  if (opts.buildSh) await chmod(join(programDir, "build.sh"), 0o755)
+
+  return programDir
+}
+
+export interface McpRunOpts {
+  runId?: string
+  phase?: string
+  experimentNumber?: number
+  originalBaseline?: number
+  currentBaseline?: number
+  bestMetric?: number
+  bestExperiment?: number
+  totalKeeps?: number
+  totalDiscards?: number
+  totalCrashes?: number
+  terminationReason?: string | null
+  results?: Array<{
+    experiment_number: number
+    commit: string
+    metric_value: number
+    status: "keep" | "discard" | "crash"
+    description: string
+  }>
+}
+
+/**
+ * Create a run directory with state.json and results.tsv for MCP tests.
+ * Returns the run directory path.
+ */
+export async function createRunForMcp(
+  cwd: string,
+  slug: string,
+  opts: McpRunOpts = {},
+): Promise<string> {
+  const runId = opts.runId ?? "20260412-100000"
+  const programDir = join(cwd, ".autoauto", "programs", slug)
+  const runDir = join(programDir, "runs", runId)
+  await mkdir(runDir, { recursive: true })
+
+  const initSha = (await import("bun").then((b) => b.$`git rev-parse HEAD`.cwd(cwd).text())).trim()
+
+  const state = {
+    run_id: runId,
+    program_slug: slug,
+    phase: opts.phase ?? "complete",
+    experiment_number: opts.experimentNumber ?? 0,
+    original_baseline: opts.originalBaseline ?? 100,
+    current_baseline: opts.currentBaseline ?? 100,
+    best_metric: opts.bestMetric ?? 100,
+    best_experiment: opts.bestExperiment ?? 0,
+    total_keeps: opts.totalKeeps ?? 0,
+    total_discards: opts.totalDiscards ?? 0,
+    total_crashes: opts.totalCrashes ?? 0,
+    branch_name: `autoauto-${slug}-${runId}`,
+    original_baseline_sha: initSha,
+    last_known_good_sha: initSha,
+    candidate_sha: null,
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    termination_reason: opts.terminationReason ?? null,
+  }
+  await Bun.write(join(runDir, "state.json"), JSON.stringify(state, null, 2))
+
+  // Write results.tsv
+  const header = "experiment\tcommit\tmetric_value\tsecondary_values\tstatus\tdescription\tmeasurement_duration_ms\tdiff_stats"
+  const rows = (opts.results ?? []).map((r) =>
+    `${r.experiment_number}\t${r.commit}\t${r.metric_value}\t\t${r.status}\t${r.description}\t5000\t`,
+  )
+  await Bun.write(join(runDir, "results.tsv"), [header, ...rows, ""].join("\n"))
+
+  return runDir
+}

--- a/src/e2e/mcp-helpers.ts
+++ b/src/e2e/mcp-helpers.ts
@@ -133,7 +133,7 @@ export async function createRunForMcp(
   const runDir = join(programDir, "runs", runId)
   await mkdir(runDir, { recursive: true })
 
-  const initSha = (await import("bun").then((b) => b.$`git rev-parse HEAD`.cwd(cwd).text())).trim()
+  const initSha = (await Bun.$`git rev-parse HEAD`.cwd(cwd).text()).trim()
 
   const state = {
     run_id: runId,

--- a/src/e2e/mcp-server.e2e.test.ts
+++ b/src/e2e/mcp-server.e2e.test.ts
@@ -1,0 +1,769 @@
+/**
+ * E2E tests for the AutoAuto MCP server — filesystem tools.
+ * Uses real MCP Client ↔ Server communication via InMemoryTransport.
+ * Zero mocking: all tool handlers run against a real temp git repo.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { join } from "node:path"
+import {
+  createMcpTestClient,
+  getTextContent,
+  getJsonContent,
+  createProgramForMcp,
+  createRunForMcp,
+  type McpTestContext,
+} from "./mcp-helpers.ts"
+import { createTestFixture, type TestFixture } from "./fixture.ts"
+
+// ---------------------------------------------------------------------------
+// list_programs
+// ---------------------------------------------------------------------------
+
+describe("MCP list_programs", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns empty message when no programs exist", async () => {
+    const result = await mcp.client.callTool({ name: "list_programs", arguments: {} })
+    expect(getTextContent(result)).toBe("No programs found.")
+  })
+
+  test("lists programs with goals and run counts", async () => {
+    await createProgramForMcp(fixture.cwd, "prog-a", {
+      programMd: "# Prog A\n\n## Goal\nReduce bundle size.\n",
+    })
+    await createProgramForMcp(fixture.cwd, "prog-b", {
+      programMd: "# Prog B\n\n## Goal\nImprove latency.\n",
+    })
+    await createRunForMcp(fixture.cwd, "prog-a", { runId: "20260101-000000" })
+
+    const result = await mcp.client.callTool({ name: "list_programs", arguments: {} })
+    const data = getJsonContent(result) as Array<{
+      name: string
+      goal: string
+      totalRuns: number
+      hasActiveRun: boolean
+    }>
+
+    expect(data).toHaveLength(2)
+    const progA = data.find((p) => p.name === "prog-a")!
+    const progB = data.find((p) => p.name === "prog-b")!
+    expect(progA.goal).toContain("bundle size")
+    expect(progA.totalRuns).toBe(1)
+    expect(progA.hasActiveRun).toBe(false)
+    expect(progB.goal).toContain("latency")
+    expect(progB.totalRuns).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// get_program
+// ---------------------------------------------------------------------------
+
+describe("MCP get_program", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns full program details", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog", {
+      programMd: "# My Program\n\n## Goal\nTest goal.\n",
+      measureSh: '#!/bin/bash\necho \'{"score": 99}\'',
+    })
+
+    const result = await mcp.client.callTool({ name: "get_program", arguments: { name: "test-prog" } })
+    const data = getJsonContent(result) as {
+      name: string
+      config: { metric_field: string }
+      program_md: string
+      measure_sh: string
+      build_sh: string | null
+    }
+
+    expect(data.name).toBe("test-prog")
+    expect(data.config.metric_field).toBe("score")
+    expect(data.program_md).toContain("My Program")
+    expect(data.measure_sh).toContain("score")
+    expect(data.build_sh).toBeNull()
+  })
+
+  test("returns error for non-existent program", async () => {
+    const result = await mcp.client.callTool({ name: "get_program", arguments: { name: "no-such" } })
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("not found")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// get_setup_guide
+// ---------------------------------------------------------------------------
+
+describe("MCP get_setup_guide", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns setup guide text", async () => {
+    const result = await mcp.client.callTool({ name: "get_setup_guide", arguments: {} })
+    const text = getTextContent(result)
+    expect(text).toContain("AutoAuto Program Setup Guide")
+    expect(text).toContain("measure.sh")
+    expect(text).toContain("config.json")
+    expect(text).toContain("quality_gates")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// create_program
+// ---------------------------------------------------------------------------
+
+describe("MCP create_program", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("creates program with all files on disk", async () => {
+    const result = await mcp.client.callTool({
+      name: "create_program",
+      arguments: {
+        name: "new-prog",
+        program_md: "# New Program\n\n## Goal\nReduce size.\n",
+        measure_sh: '#!/bin/bash\necho \'{"bytes": 1000}\'',
+        build_sh: "#!/bin/bash\nnpm run build",
+        config: {
+          metric_field: "bytes",
+          direction: "lower",
+          noise_threshold: 0.01,
+          repeats: 1,
+          max_experiments: 5,
+          quality_gates: {},
+        },
+      },
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(getTextContent(result)).toContain("created")
+
+    // Verify filesystem
+    const programDir = join(fixture.cwd, ".autoauto", "programs", "new-prog")
+    const config = await Bun.file(join(programDir, "config.json")).json()
+    expect(config.metric_field).toBe("bytes")
+    expect(config.direction).toBe("lower")
+
+    const programMd = await Bun.file(join(programDir, "program.md")).text()
+    expect(programMd).toContain("New Program")
+
+    const measureSh = await Bun.file(join(programDir, "measure.sh")).text()
+    expect(measureSh).toContain("bytes")
+
+    const buildSh = await Bun.file(join(programDir, "build.sh")).text()
+    expect(buildSh).toContain("npm run build")
+  })
+
+  test("rejects duplicate program name", async () => {
+    await createProgramForMcp(fixture.cwd, "existing-prog")
+
+    const result = await mcp.client.callTool({
+      name: "create_program",
+      arguments: {
+        name: "existing-prog",
+        program_md: "# Dup",
+        measure_sh: "#!/bin/bash\necho '{}'",
+        config: {
+          metric_field: "x",
+          direction: "lower",
+          noise_threshold: 0.01,
+          repeats: 1,
+          max_experiments: 5,
+        },
+      },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("already exists")
+  })
+
+  test("validates slug format", async () => {
+    // Zod validation should reject path-traversal slugs
+    try {
+      const result = await mcp.client.callTool({
+        name: "create_program",
+        arguments: {
+          name: "../../evil",
+          program_md: "# Evil",
+          measure_sh: "#!/bin/bash",
+          config: {
+            metric_field: "x",
+            direction: "lower",
+            noise_threshold: 0.01,
+            repeats: 1,
+            max_experiments: 5,
+          },
+        },
+      })
+      // If we get a result, it should be an error
+      expect(result.isError).toBe(true)
+    } catch {
+      // MCP SDK may throw on schema validation failure — that's fine
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// update_program
+// ---------------------------------------------------------------------------
+
+describe("MCP update_program", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("updates selective files", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog", {
+      programMd: "# Original",
+      measureSh: '#!/bin/bash\necho \'{"score": 1}\'',
+    })
+
+    const result = await mcp.client.callTool({
+      name: "update_program",
+      arguments: {
+        name: "test-prog",
+        measure_sh: '#!/bin/bash\necho \'{"score": 2}\'',
+      },
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(getTextContent(result)).toContain("Updated measure.sh")
+
+    // measure.sh changed
+    const programDir = join(fixture.cwd, ".autoauto", "programs", "test-prog")
+    const measureSh = await Bun.file(join(programDir, "measure.sh")).text()
+    expect(measureSh).toContain("score\": 2")
+
+    // program.md unchanged
+    const programMd = await Bun.file(join(programDir, "program.md")).text()
+    expect(programMd).toContain("Original")
+  })
+
+  test("returns error for non-existent program", async () => {
+    const result = await mcp.client.callTool({
+      name: "update_program",
+      arguments: { name: "no-such", program_md: "# New" },
+    })
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("not found")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// delete_program
+// ---------------------------------------------------------------------------
+
+describe("MCP delete_program", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("deletes program and all runs", async () => {
+    await createProgramForMcp(fixture.cwd, "to-delete")
+    await createRunForMcp(fixture.cwd, "to-delete", {
+      runId: "20260101-000000",
+      phase: "complete",
+    })
+
+    const result = await mcp.client.callTool({
+      name: "delete_program",
+      arguments: { name: "to-delete", confirm: true },
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(getTextContent(result)).toContain("deleted")
+
+    // Verify directory removed
+    const exists = await Bun.file(join(fixture.cwd, ".autoauto", "programs", "to-delete", "config.json")).exists()
+    expect(exists).toBe(false)
+  })
+
+  test("refuses deletion of active run", async () => {
+    await createProgramForMcp(fixture.cwd, "active-prog")
+    await createRunForMcp(fixture.cwd, "active-prog", {
+      runId: "20260101-000000",
+      phase: "agent_running",
+    })
+
+    const result = await mcp.client.callTool({
+      name: "delete_program",
+      arguments: { name: "active-prog", confirm: true },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("active run")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// list_runs
+// ---------------------------------------------------------------------------
+
+describe("MCP list_runs", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns message when no runs exist", async () => {
+    await createProgramForMcp(fixture.cwd, "empty-prog")
+
+    const result = await mcp.client.callTool({ name: "list_runs", arguments: { name: "empty-prog" } })
+    expect(getTextContent(result)).toBe("No runs found.")
+  })
+
+  test("lists runs with summary info", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog", {
+      runId: "20260101-000000",
+      phase: "complete",
+      totalKeeps: 3,
+      totalDiscards: 2,
+      totalCrashes: 1,
+      bestMetric: 90,
+      originalBaseline: 100,
+    })
+    await createRunForMcp(fixture.cwd, "test-prog", {
+      runId: "20260102-000000",
+      phase: "complete",
+      totalKeeps: 5,
+      bestMetric: 80,
+      originalBaseline: 100,
+    })
+
+    const result = await mcp.client.callTool({ name: "list_runs", arguments: { name: "test-prog" } })
+    const data = getJsonContent(result) as Array<{ run_id: string; phase: string; experiments: number }>
+
+    expect(data).toHaveLength(2)
+    expect(data.some((r) => r.run_id === "20260101-000000")).toBe(true)
+    expect(data.some((r) => r.run_id === "20260102-000000")).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// get_run_status
+// ---------------------------------------------------------------------------
+
+describe("MCP get_run_status", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns status for a specific run", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog", {
+      runId: "20260412-100000",
+      phase: "complete",
+      experimentNumber: 5,
+      originalBaseline: 100,
+      bestMetric: 85,
+      bestExperiment: 3,
+      totalKeeps: 3,
+      totalDiscards: 1,
+      totalCrashes: 1,
+    })
+
+    const result = await mcp.client.callTool({
+      name: "get_run_status",
+      arguments: { name: "test-prog", run_id: "20260412-100000" },
+    })
+
+    const data = getJsonContent(result) as Record<string, unknown>
+    expect(data.run_id).toBe("20260412-100000")
+    expect(data.phase).toBe("complete")
+    expect(data.experiment_number).toBe(5)
+    expect(data.best_metric).toBe(85)
+    expect(data.keeps).toBe(3)
+    expect(data.discards).toBe(1)
+    expect(data.crashes).toBe(1)
+    expect(data.daemon_alive).toBe(false)
+  })
+
+  test("returns latest run when run_id omitted", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog", { runId: "20260101-000000", phase: "complete" })
+    await createRunForMcp(fixture.cwd, "test-prog", { runId: "20260102-000000", phase: "complete" })
+
+    const result = await mcp.client.callTool({
+      name: "get_run_status",
+      arguments: { name: "test-prog" },
+    })
+
+    const data = getJsonContent(result) as Record<string, unknown>
+    // Latest run (by directory sort) should be returned
+    expect(data.run_id).toBe("20260102-000000")
+  })
+
+  test("returns error for non-existent program", async () => {
+    const result = await mcp.client.callTool({
+      name: "get_run_status",
+      arguments: { name: "no-such" },
+    })
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("not found")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// get_run_results
+// ---------------------------------------------------------------------------
+
+describe("MCP get_run_results", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns experiment results table", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog", {
+      results: [
+        { experiment_number: 0, commit: "abc1234", metric_value: 100, status: "keep", description: "baseline" },
+        { experiment_number: 1, commit: "def5678", metric_value: 95, status: "keep", description: "optimize loop" },
+        { experiment_number: 2, commit: "ghi9012", metric_value: 98, status: "discard", description: "bad change" },
+      ],
+    })
+
+    const result = await mcp.client.callTool({
+      name: "get_run_results",
+      arguments: { name: "test-prog" },
+    })
+
+    const data = getJsonContent(result) as { total_results: number; results: Array<{ experiment_number: number; status: string }> }
+    expect(data.total_results).toBe(3)
+    expect(data.results).toHaveLength(3)
+    expect(data.results[0].status).toBe("keep")
+    expect(data.results[1].status).toBe("keep")
+    expect(data.results[2].status).toBe("discard")
+  })
+
+  test("respects limit parameter", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog", {
+      results: [
+        { experiment_number: 0, commit: "a000000", metric_value: 100, status: "keep", description: "baseline" },
+        { experiment_number: 1, commit: "a111111", metric_value: 95, status: "keep", description: "exp 1" },
+        { experiment_number: 2, commit: "a222222", metric_value: 93, status: "keep", description: "exp 2" },
+        { experiment_number: 3, commit: "a333333", metric_value: 97, status: "discard", description: "exp 3" },
+      ],
+    })
+
+    const result = await mcp.client.callTool({
+      name: "get_run_results",
+      arguments: { name: "test-prog", limit: 2 },
+    })
+
+    const data = getJsonContent(result) as { total_results: number; results: Array<{ experiment_number: number }> }
+    expect(data.total_results).toBe(4)
+    expect(data.results).toHaveLength(2)
+    // Last 2 results
+    expect(data.results[0].experiment_number).toBe(2)
+    expect(data.results[1].experiment_number).toBe(3)
+  })
+
+  test("returns message when no results yet", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog")
+
+    const result = await mcp.client.callTool({
+      name: "get_run_results",
+      arguments: { name: "test-prog" },
+    })
+    expect(getTextContent(result)).toContain("No results yet")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// get_experiment_log
+// ---------------------------------------------------------------------------
+
+describe("MCP get_experiment_log", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns stream log content", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", {
+      results: [
+        { experiment_number: 0, commit: "aaa0000", metric_value: 100, status: "keep", description: "baseline" },
+        { experiment_number: 1, commit: "bbb1111", metric_value: 90, status: "keep", description: "exp 1" },
+      ],
+    })
+
+    // Write a stream log file
+    await Bun.write(join(runDir, "stream-001.log"), "Agent thinking...\nEditing file.ts\nDone.")
+
+    const result = await mcp.client.callTool({
+      name: "get_experiment_log",
+      arguments: { name: "test-prog", experiment_number: 1 },
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(getTextContent(result)).toContain("Agent thinking...")
+    expect(getTextContent(result)).toContain("Done.")
+  })
+
+  test("returns error when no log exists", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog")
+
+    const result = await mcp.client.callTool({
+      name: "get_experiment_log",
+      arguments: { name: "test-prog", experiment_number: 5 },
+    })
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("No log found")
+  })
+
+  test("handles 'latest' experiment_number", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", {
+      results: [
+        { experiment_number: 0, commit: "aaa0000", metric_value: 100, status: "keep", description: "baseline" },
+        { experiment_number: 1, commit: "bbb1111", metric_value: 90, status: "keep", description: "exp 1" },
+        { experiment_number: 2, commit: "ccc2222", metric_value: 85, status: "keep", description: "exp 2" },
+      ],
+    })
+
+    await Bun.write(join(runDir, "stream-002.log"), "Latest experiment log content")
+
+    const result = await mcp.client.callTool({
+      name: "get_experiment_log",
+      arguments: { name: "test-prog", experiment_number: "latest" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(getTextContent(result)).toContain("Latest experiment log content")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// get_run_summary
+// ---------------------------------------------------------------------------
+
+describe("MCP get_run_summary", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns existing summary", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", { phase: "complete" })
+    await Bun.write(join(runDir, "summary.md"), "# Run Summary\n\nGreat results!")
+
+    const result = await mcp.client.callTool({
+      name: "get_run_summary",
+      arguments: { name: "test-prog" },
+    })
+
+    const data = getJsonContent(result) as { has_summary: boolean; generated: boolean; summary: string }
+    expect(data.has_summary).toBe(true)
+    expect(data.generated).toBe(false)
+    expect(data.summary).toContain("Great results!")
+  })
+
+  test("generates stats summary for completed run", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", {
+      phase: "complete",
+      totalKeeps: 3,
+      totalDiscards: 2,
+      bestMetric: 80,
+      originalBaseline: 100,
+      results: [
+        { experiment_number: 0, commit: "aaa0000", metric_value: 100, status: "keep", description: "baseline" },
+        { experiment_number: 1, commit: "bbb1111", metric_value: 80, status: "keep", description: "improved" },
+      ],
+    })
+
+    const result = await mcp.client.callTool({
+      name: "get_run_summary",
+      arguments: { name: "test-prog", generate: true },
+    })
+
+    const data = getJsonContent(result) as { has_summary: boolean; generated: boolean; summary: string }
+    expect(data.has_summary).toBe(true)
+    expect(data.generated).toBe(true)
+    expect(data.summary).toBeTruthy()
+
+    // Verify file was written to disk
+    const summaryExists = await Bun.file(join(runDir, "summary.md")).exists()
+    expect(summaryExists).toBe(true)
+  })
+
+  test("returns hint when no summary and generate=false", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog", { phase: "complete" })
+
+    const result = await mcp.client.callTool({
+      name: "get_run_summary",
+      arguments: { name: "test-prog" },
+    })
+
+    const data = getJsonContent(result) as { has_summary: boolean; hint: string }
+    expect(data.has_summary).toBe(false)
+    expect(data.hint).toContain("generate=true")
+  })
+
+  test("rejects generate for active run", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog", { phase: "agent_running" })
+
+    const result = await mcp.client.callTool({
+      name: "get_run_summary",
+      arguments: { name: "test-prog", generate: true },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("completed or crashed")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validate_measurement (real subprocess)
+// ---------------------------------------------------------------------------
+
+describe("MCP validate_measurement", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("validates a working measurement script", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog", {
+      measureSh: '#!/usr/bin/env bash\nset -euo pipefail\necho \'{"score": 42}\'',
+    })
+
+    const result = await mcp.client.callTool({
+      name: "validate_measurement",
+      arguments: { name: "test-prog", runs: 2 },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as { validation: { success: boolean } }
+    expect(data.validation.success).toBe(true)
+  }, 60_000) // generous timeout for subprocess
+
+  test("returns error for missing program", async () => {
+    const result = await mcp.client.callTool({
+      name: "validate_measurement",
+      arguments: { name: "no-such", runs: 1 },
+    })
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("not found")
+  })
+}, 90_000)

--- a/src/e2e/mcp-server.e2e.test.ts
+++ b/src/e2e/mcp-server.e2e.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
 import { join } from "node:path"
+import { mkdir } from "node:fs/promises"
 import {
   createMcpTestClient,
   getTextContent,
@@ -67,6 +68,24 @@ describe("MCP list_programs", () => {
     expect(progA.hasActiveRun).toBe(false)
     expect(progB.goal).toContain("latency")
     expect(progB.totalRuns).toBe(0)
+  })
+
+  test("uses the detected project root when started in a subdirectory", async () => {
+    await createProgramForMcp(fixture.cwd, "root-prog", {
+      programMd: "# Root Program\n\n## Goal\nMeasure from repo root.\n",
+    })
+
+    const nestedCwd = join(fixture.cwd, "packages", "app")
+    await mkdir(nestedCwd, { recursive: true })
+    const nestedMcp = await createMcpTestClient(nestedCwd)
+
+    try {
+      const result = await nestedMcp.client.callTool({ name: "list_programs", arguments: {} })
+      const data = getJsonContent(result) as Array<{ name: string }>
+      expect(data.some((program) => program.name === "root-prog")).toBe(true)
+    } finally {
+      await nestedMcp.cleanup()
+    }
   })
 })
 
@@ -244,8 +263,39 @@ describe("MCP create_program", () => {
       })
       // If we get a result, it should be an error
       expect(result.isError).toBe(true)
-    } catch {
-      // MCP SDK may throw on schema validation failure — that's fine
+    } catch (err) {
+      expect(String(err)).toMatch(/name|slug|invalid|validation/i)
+    }
+  })
+
+  test("creates program files under the detected project root", async () => {
+    const nestedCwd = join(fixture.cwd, "apps", "web")
+    await mkdir(nestedCwd, { recursive: true })
+    const nestedMcp = await createMcpTestClient(nestedCwd)
+
+    try {
+      const result = await nestedMcp.client.callTool({
+        name: "create_program",
+        arguments: {
+          name: "nested-prog",
+          program_md: "# Nested Program\n\n## Goal\nWrite into root .autoauto.\n",
+          measure_sh: '#!/bin/bash\necho \'{"bytes": 1000}\'',
+          config: {
+            metric_field: "bytes",
+            direction: "lower",
+            noise_threshold: 0.01,
+            repeats: 1,
+            max_experiments: 5,
+            quality_gates: {},
+          },
+        },
+      })
+
+      expect(result.isError).toBeFalsy()
+      expect(await Bun.file(join(fixture.cwd, ".autoauto", "programs", "nested-prog", "config.json")).exists()).toBe(true)
+      expect(await Bun.file(join(nestedCwd, ".autoauto", "programs", "nested-prog", "config.json")).exists()).toBe(false)
+    } finally {
+      await nestedMcp.cleanup()
     }
   })
 })

--- a/src/e2e/mcp-server.e2e.test.ts
+++ b/src/e2e/mcp-server.e2e.test.ts
@@ -15,6 +15,9 @@ import {
   type McpTestContext,
 } from "./mcp-helpers.ts"
 import { createTestFixture, type TestFixture } from "./fixture.ts"
+import { setProvider } from "../lib/agent/index.ts"
+import { MockProvider } from "../lib/agent/mock-provider.ts"
+import { saveProjectConfig } from "../lib/config.ts"
 
 // ---------------------------------------------------------------------------
 // list_programs
@@ -767,3 +770,231 @@ describe("MCP validate_measurement", () => {
     expect(getTextContent(result)).toContain("not found")
   })
 }, 90_000)
+
+// ---------------------------------------------------------------------------
+// conversational sessions
+// ---------------------------------------------------------------------------
+
+describe("MCP conversational sessions", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    setProvider("claude", new MockProvider([
+      { type: "tool_use", tool: "Read", input: { file_path: "/tmp/test.txt" } },
+      { type: "assistant_complete", text: "Mock reply." },
+      { type: "result", success: true },
+    ]))
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("start_setup_session creates a session and returns first reply", async () => {
+    const result = await mcp.client.callTool({
+      name: "start_setup_session",
+      arguments: {
+        mode: "direct",
+        message: "I want to optimize bundle size.",
+      },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as {
+      session_id: string
+      kind: string
+      assistant_message: string
+      tool_events: string[]
+      messages: Array<{ role: string; content: string }>
+    }
+
+    expect(data.kind).toBe("setup")
+    expect(data.assistant_message).toBe("Mock reply.")
+    expect(data.tool_events[0]).toContain("Reading")
+    expect(data.messages).toEqual([
+      { role: "user", content: "I want to optimize bundle size." },
+      { role: "assistant", content: "Mock reply." },
+    ])
+  })
+
+  test("sessions persist across MCP server reconnects", async () => {
+    const started = await mcp.client.callTool({
+      name: "start_setup_session",
+      arguments: { mode: "direct", message: "First turn." },
+    })
+    const { session_id } = getJsonContent(started) as { session_id: string }
+
+    await mcp.cleanup()
+    mcp = await createMcpTestClient(fixture.cwd)
+
+    const replied = await mcp.client.callTool({
+      name: "send_session_message",
+      arguments: {
+        session_id,
+        message: "Second turn.",
+      },
+    })
+
+    expect(replied.isError).toBeFalsy()
+    const session = await mcp.client.callTool({
+      name: "get_session",
+      arguments: { session_id },
+    })
+
+    const data = getJsonContent(session) as {
+      messages: Array<{ role: string; content: string }>
+    }
+    expect(data.messages).toEqual([
+      { role: "user", content: "First turn." },
+      { role: "assistant", content: "Mock reply." },
+      { role: "user", content: "Second turn." },
+      { role: "assistant", content: "Mock reply." },
+    ])
+  })
+
+  test("start_update_session auto-seeds from program context", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+
+    const result = await mcp.client.callTool({
+      name: "start_update_session",
+      arguments: { name: "test-prog" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as {
+      kind: string
+      program_slug: string
+      assistant_message: string
+      messages: Array<{ role: string; content: string }>
+    }
+
+    expect(data.kind).toBe("update")
+    expect(data.program_slug).toBe("test-prog")
+    expect(data.assistant_message).toBe("Mock reply.")
+    expect(data.messages[0]?.role).toBe("user")
+    expect(data.messages[0]?.content).toContain("No previous runs found")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// config / models / auth
+// ---------------------------------------------------------------------------
+
+describe("MCP config and provider metadata", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    setProvider("claude", new MockProvider(
+      [],
+      { authenticated: true, account: { email: "claude@example.com" } },
+      [{ provider: "claude", model: "sonnet", label: "Sonnet", isDefault: true }],
+    ))
+    setProvider("codex", new MockProvider(
+      [],
+      { authenticated: false, error: "Codex login required" },
+      [{ provider: "codex", model: "default", label: "Codex Default", isDefault: true }],
+    ))
+    setProvider("opencode", new MockProvider(
+      [],
+      { authenticated: true, account: { email: "opencode@example.com" } },
+      [{ provider: "opencode", model: "openai/gpt-5", label: "GPT-5" }],
+    ))
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("get_config returns defaults when no config exists", async () => {
+    const result = await mcp.client.callTool({ name: "get_config", arguments: {} })
+    const data = getJsonContent(result) as {
+      executionModel: { provider: string; model: string; effort: string }
+      supportModel: { provider: string; model: string; effort: string }
+      ideasBacklogEnabled: boolean
+    }
+
+    expect(data.executionModel).toEqual({ provider: "claude", model: "sonnet", effort: "high" })
+    expect(data.supportModel).toEqual({ provider: "claude", model: "sonnet", effort: "high" })
+    expect(data.ideasBacklogEnabled).toBe(true)
+  })
+
+  test("set_config merges provided fields", async () => {
+    await saveProjectConfig(fixture.cwd, {
+      executionModel: { provider: "claude", model: "sonnet", effort: "high" },
+      supportModel: { provider: "claude", model: "sonnet", effort: "high" },
+      executionFallbackModel: null,
+      ideasBacklogEnabled: true,
+      notificationPreset: "off",
+      notificationCommand: null,
+    })
+
+    const result = await mcp.client.callTool({
+      name: "set_config",
+      arguments: {
+        supportModel: { provider: "opencode", model: "openai/gpt-5", effort: "high" },
+        executionFallbackModel: { provider: "codex", model: "default", effort: "medium" },
+        ideasBacklogEnabled: false,
+      },
+    })
+
+    const data = getJsonContent(result) as {
+      executionModel: { provider: string; model: string; effort: string }
+      supportModel: { provider: string; model: string; effort: string }
+      executionFallbackModel: { provider: string; model: string; effort: string } | null
+      ideasBacklogEnabled: boolean
+    }
+
+    expect(data.executionModel).toEqual({ provider: "claude", model: "sonnet", effort: "high" })
+    expect(data.supportModel).toEqual({ provider: "opencode", model: "openai/gpt-5", effort: "high" })
+    expect(data.executionFallbackModel).toEqual({ provider: "codex", model: "default", effort: "medium" })
+    expect(data.ideasBacklogEnabled).toBe(false)
+  })
+
+  test("list_models returns models for all providers", async () => {
+    const result = await mcp.client.callTool({ name: "list_models", arguments: {} })
+    const data = getJsonContent(result) as Array<{
+      provider: string
+      available: boolean
+      default_model: string | null
+      models: Array<{ model: string }>
+    }>
+
+    expect(data).toHaveLength(3)
+    expect(data.find((p) => p.provider === "claude")).toMatchObject({
+      available: true,
+      default_model: "sonnet",
+      models: [{ model: "sonnet" }],
+    })
+    expect(data.find((p) => p.provider === "codex")).toMatchObject({
+      available: true,
+      default_model: "default",
+      models: [{ model: "default" }],
+    })
+  })
+
+  test("check_auth returns auth state for all providers", async () => {
+    const result = await mcp.client.callTool({ name: "check_auth", arguments: {} })
+    const data = getJsonContent(result) as Array<{
+      provider: string
+      authenticated: boolean
+      error: string | null
+    }>
+
+    expect(data.find((p) => p.provider === "claude")).toMatchObject({
+      authenticated: true,
+      error: null,
+    })
+    expect(data.find((p) => p.provider === "codex")).toMatchObject({
+      authenticated: false,
+      error: "Codex login required",
+    })
+  })
+})

--- a/src/e2e/stale-run-cleanup.e2e.test.tsx
+++ b/src/e2e/stale-run-cleanup.e2e.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { join } from "node:path"
+import { renderTui, noop, type TuiHarness } from "./helpers.ts"
+import { HomeScreen } from "../screens/HomeScreen.tsx"
+import { resetProjectRoot } from "../lib/programs.ts"
+import { createTestFixture, type TestFixture } from "./fixture.ts"
+import { readState } from "../lib/run.ts"
+
+let harness: TuiHarness | null = null
+
+afterEach(async () => {
+  await harness?.destroy()
+  harness = null
+  resetProjectRoot()
+})
+
+describe("Stale run cleanup on HomeScreen load", () => {
+  let fixture: TestFixture
+
+  afterEach(async () => {
+    await fixture.cleanup()
+  })
+
+  test("run stuck in agent_running with dead daemon is marked crashed", async () => {
+    fixture = await createTestFixture()
+    await fixture.createProgram("stale-prog", {
+      metric_field: "score",
+      direction: "lower",
+      max_experiments: 10,
+    })
+    const runDir = await fixture.createRun("stale-prog", {
+      run_id: "20260401-100000",
+      phase: "agent_running",
+      experiment_number: 2,
+      total_keeps: 0,
+      total_discards: 1,
+    })
+
+    // Write a daemon.json with a dead PID and stale heartbeat to simulate crash
+    await Bun.write(
+      join(runDir, "daemon.json"),
+      JSON.stringify({
+        run_id: "20260401-100000",
+        pid: 999999, // non-existent PID
+        started_at: "2026-04-01T10:00:00.000Z",
+        worktree_path: "/tmp/nonexistent-worktree",
+        daemon_id: "test-dead-daemon",
+        heartbeat_at: "2026-04-01T10:05:00.000Z", // stale
+      }),
+    )
+
+    // Verify state is agent_running before loading HomeScreen
+    const before = await readState(runDir)
+    expect(before.phase).toBe("agent_running")
+
+    // Loading the HomeScreen triggers cleanupStaleRuns
+    harness = await renderTui(
+      <HomeScreen
+        cwd={fixture.cwd}
+        navigate={noop}
+        onSelectProgram={noop}
+        onSelectRun={noop}
+        onUpdateProgram={noop}
+        onFinalizeRun={noop}
+        onResumeDraft={noop}
+      />,
+      { width: 120 },
+    )
+    await harness.waitForText("stale-prog")
+
+    // Verify state was cleaned up on disk
+    const after = await readState(runDir)
+    expect(after.phase).toBe("crashed")
+    expect(after.error_phase).toBe("agent_running")
+  })
+
+  test("stale run becomes deletable after cleanup", async () => {
+    fixture = await createTestFixture()
+    await fixture.createProgram("del-stale", {
+      metric_field: "score",
+      direction: "lower",
+      max_experiments: 10,
+    })
+    const runDir = await fixture.createRun("del-stale", {
+      run_id: "20260401-200000",
+      phase: "measuring",
+      experiment_number: 3,
+    })
+
+    // Write a daemon.json with dead PID
+    await Bun.write(
+      join(runDir, "daemon.json"),
+      JSON.stringify({
+        run_id: "20260401-200000",
+        pid: 999999,
+        started_at: "2026-04-01T10:00:00.000Z",
+        worktree_path: "/tmp/nonexistent-worktree",
+        daemon_id: "test-dead-daemon-2",
+        heartbeat_at: "2026-04-01T10:05:00.000Z",
+      }),
+    )
+
+    harness = await renderTui(
+      <HomeScreen
+        cwd={fixture.cwd}
+        navigate={noop}
+        onSelectProgram={noop}
+        onSelectRun={noop}
+        onUpdateProgram={noop}
+        onFinalizeRun={noop}
+        onResumeDraft={noop}
+      />,
+      { width: 120 },
+    )
+    await harness.waitForText("del-stale")
+
+    // Tab to runs panel, try to delete
+    await harness.tab()
+    await harness.press("d")
+    const frame = await harness.waitForText("Delete this run?")
+    expect(frame).toContain("20260401-200000")
+  })
+
+  test("run without daemon.json is NOT cleaned up", async () => {
+    fixture = await createTestFixture()
+    await fixture.createProgram("no-daemon", {
+      metric_field: "score",
+      direction: "lower",
+      max_experiments: 10,
+    })
+    const runDir = await fixture.createRun("no-daemon", {
+      run_id: "20260401-300000",
+      phase: "idle",
+      experiment_number: 3,
+    })
+
+    // No daemon.json — should not be cleaned up
+    harness = await renderTui(
+      <HomeScreen
+        cwd={fixture.cwd}
+        navigate={noop}
+        onSelectProgram={noop}
+        onSelectRun={noop}
+        onUpdateProgram={noop}
+        onFinalizeRun={noop}
+        onResumeDraft={noop}
+      />,
+      { width: 120 },
+    )
+    await harness.waitForText("no-daemon")
+
+    // State should remain idle (not cleaned up)
+    const after = await readState(runDir)
+    expect(after.phase).toBe("idle")
+  })
+})

--- a/src/lib/agent/default-providers.ts
+++ b/src/lib/agent/default-providers.ts
@@ -1,10 +1,23 @@
-import { setProvider } from "./index.ts"
+import { hasProvider, setProvider } from "./index.ts"
 import { ClaudeProvider } from "./claude-provider.ts"
 import { OpenCodeProvider } from "./opencode-provider.ts"
 import { CodexProvider } from "./codex-provider.ts"
 
 export function registerDefaultProviders(): void {
-  setProvider("claude", new ClaudeProvider())
-  setProvider("opencode", new OpenCodeProvider())
-  setProvider("codex", new CodexProvider())
+  const factories = [
+    ["claude", () => new ClaudeProvider()],
+    ["opencode", () => new OpenCodeProvider()],
+    ["codex", () => new CodexProvider()],
+  ] as const
+
+  for (const [id, factory] of factories) {
+    if (hasProvider(id)) continue
+    try {
+      setProvider(id, factory())
+    } catch (err) {
+      if (process.env.DEV) {
+        process.stderr.write(`[providers] ${id} unavailable: ${err}\n`)
+      }
+    }
+  }
 }

--- a/src/lib/agent/index.ts
+++ b/src/lib/agent/index.ts
@@ -20,6 +20,10 @@ export function setProvider(id: AgentProviderID, p: AgentProvider): void {
   providers.set(id, p)
 }
 
+export function hasProvider(id: AgentProviderID): boolean {
+  return providers.has(id)
+}
+
 /** Get the active agent provider. Throws if not yet configured. */
 export function getProvider(id: AgentProviderID = "claude"): AgentProvider {
   const provider = providers.get(id)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -102,10 +102,10 @@ export function cycleChoice<T>(choices: readonly T[], current: T, direction: -1 
 }
 
 export const EFFORT_DESCRIPTIONS: Record<EffortLevel, string> = {
-  low: "Fastest, cheapest — minimal thinking",
-  medium: "Balanced speed and quality",
-  high: "Deep reasoning (default)",
-  max: "Maximum effort (Opus only)",
+  low: "Fastest and cheapest — good for bulk exploration or simple tasks",
+  medium: "Balanced speed and quality — good for most optimization runs",
+  high: "Deep reasoning (default) — best for complex problems worth the extra cost",
+  max: "Maximum reasoning (Opus only) — for hard problems that defeated high effort",
 }
 
 function normalizeModelSlot(slot: Partial<ModelSlot> | undefined): ModelSlot {

--- a/src/lib/daemon-error.test.ts
+++ b/src/lib/daemon-error.test.ts
@@ -217,8 +217,8 @@ describe("daemon startup failure", () => {
       // daemon.log should contain something about the missing config
       const logTail = await readDaemonLogTail(result.runDir)
       expect(logTail.length).toBeGreaterThan(0)
-      // The daemon writes "Daemon fatal error: ..." for unhandled exceptions
-      expect(logTail).toContain("Daemon fatal error")
+      // The daemon logs an error referencing the missing config.json
+      expect(logTail).toContain("config.json")
 
     } finally {
       await releaseLock(programDir).catch(() => {})

--- a/src/lib/daemon-spawn.ts
+++ b/src/lib/daemon-spawn.ts
@@ -1,6 +1,5 @@
 import { open } from "node:fs/promises"
-import { join, dirname } from "node:path"
-import { fileURLToPath } from "node:url"
+import { join } from "node:path"
 import { spawn } from "node:child_process"
 import { randomUUID } from "node:crypto"
 import { generateRunId } from "./run.ts"
@@ -17,6 +16,7 @@ import {
   type DaemonJson,
   type RunConfig,
 } from "./daemon-lifecycle.ts"
+import { getSelfCommand } from "./self-command.ts"
 
 /**
  * Prepares and spawns a new daemon for a run. Does everything the TUI needs
@@ -100,15 +100,15 @@ export async function spawnDaemon(
     await writeRunConfig(runDir, runConfig)
 
     // 4. Spawn detached daemon
-    const daemonPath = join(dirname(fileURLToPath(import.meta.url)), "..", "daemon.ts")
     const logPath = join(runDir, "daemon.log")
     const logFd = await open(logPath, "w")
+    const daemonExec = getSelfCommand("__daemon")
 
-    const daemonArgs = [daemonPath, "--program", programSlug, "--run-id", runId, "--main-root", mainRoot, "--worktree", worktreePath, "--daemon-id", daemonId]
+    const daemonArgs = [...daemonExec.args, "--program", programSlug, "--run-id", runId, "--main-root", mainRoot, "--worktree", worktreePath, "--daemon-id", daemonId]
     if (!useWorktree) daemonArgs.push("--in-place")
 
     const proc = spawn(
-      "bun",
+      daemonExec.command,
       daemonArgs,
       {
         detached: true,

--- a/src/lib/daemon-status.ts
+++ b/src/lib/daemon-status.ts
@@ -2,8 +2,8 @@ import { join } from "node:path"
 import { rm } from "node:fs/promises"
 import { $ } from "bun"
 import { streamLogName } from "./daemon-callbacks.ts"
-import type { RunState, ExperimentResult } from "./run.ts"
-import { readAllResults, readState, getMetricHistory, backfillFinalizedAt, listRuns, isRunActive } from "./run.ts"
+import type { RunState, ExperimentResult, RunInfo } from "./run.ts"
+import { readAllResults, readState, getMetricHistory, backfillFinalizedAt, listRuns, isRunActive, writeState } from "./run.ts"
 import type { ProgramConfig } from "./programs.ts"
 import { loadProgramConfig, getProgramDir } from "./programs.ts"
 import {
@@ -270,4 +270,51 @@ export async function abortAndDeleteActiveRuns(
   }
 
   await releaseLock(programDir)
+}
+
+// --- Stale Run Cleanup ---
+
+/**
+ * Detects runs that appear active but whose daemon is dead, and marks them
+ * as crashed. Called from loadHomeData to clean up after daemon crashes that
+ * happened while the TUI wasn't watching (e.g. TUI was closed).
+ *
+ * Only acts when daemon.json exists (proving a daemon once started). Runs
+ * with no daemon.json are left untouched — they may be test fixtures or in
+ * a startup race.
+ *
+ * @param programDir - The program directory (used for lock release)
+ * @param runs - All runs for the program (mutated in-place if cleaned up)
+ */
+export async function cleanupStaleRuns(programDir: string, runs: RunInfo[]): Promise<void> {
+  let cleaned = false
+
+  for (const run of runs) {
+    if (!isRunActive(run) || !run.state) continue
+
+    const status = await getDaemonStatus(run.run_dir)
+    // Only clean up if daemon.json exists (daemon once started) and is now dead
+    if (status.alive || status.starting || !status.daemonJson) continue
+
+    // Daemon is dead but state is non-terminal — mark as crashed
+    const logTail = await readDaemonLogTail(run.run_dir)
+    const crashedState: RunState = {
+      ...run.state,
+      phase: "crashed",
+      error: logTail || "Daemon died unexpectedly",
+      error_phase: run.state.phase,
+      updated_at: new Date().toISOString(),
+    }
+    await writeState(run.run_dir, crashedState)
+    run.state = crashedState // update in-place so callers see the fix
+    cleaned = true
+  }
+
+  if (cleaned) {
+    // Release program lock if no more active runs remain
+    const stillActive = runs.some((r) => isRunActive(r))
+    if (!stillActive) {
+      await releaseLock(programDir)
+    }
+  }
 }

--- a/src/lib/finalize.ts
+++ b/src/lib/finalize.ts
@@ -83,7 +83,7 @@ export async function buildFinalizeInitialMessage(
   let diffSection: string
   if (diff.length > MAX_DIFF_LENGTH) {
     diffSection = diff.slice(0, MAX_DIFF_LENGTH) +
-      `\n\n... (diff truncated at ${MAX_DIFF_LENGTH} chars — use \`git diff ${state.original_baseline_sha} HEAD\` for the full output)`
+      `\n\n... (diff truncated at ${MAX_DIFF_LENGTH} chars — use \`git diff ${state.original_baseline_sha} ${headRef}\` for the full output)`
   } else {
     diffSection = diff
   }

--- a/src/lib/finalize.ts
+++ b/src/lib/finalize.ts
@@ -40,10 +40,12 @@ export async function buildFinalizeContext(
   state: RunState,
   config: ProgramConfig,
   projectRoot?: string,
+  /** Git ref to use as the "current" end of diffs. Defaults to "HEAD". */
+  headRef = "HEAD",
 ): Promise<FinalizeContext> {
   const [results, changedFiles] = await Promise.all([
     readAllResults(runDir),
-    getFilesChangedBetween(cwd, state.original_baseline_sha, "HEAD"),
+    getFilesChangedBetween(cwd, state.original_baseline_sha, headRef),
   ])
   const stats = getRunStats(state, config.direction)
 
@@ -62,12 +64,16 @@ export async function buildFinalizeContext(
   }
 }
 
-export async function buildFinalizeInitialMessage(context: FinalizeContext): Promise<string> {
+export async function buildFinalizeInitialMessage(
+  context: FinalizeContext,
+  /** Git ref to use as the "current" end of diffs. Defaults to "HEAD". */
+  headRef = "HEAD",
+): Promise<string> {
   const { state, results, stats, changedFiles, cwd } = context
 
   const [diff, gitLog] = await Promise.all([
-    getDiffBetween(cwd, state.original_baseline_sha, "HEAD"),
-    getRecentLog(cwd, 50),
+    getDiffBetween(cwd, state.original_baseline_sha, headRef),
+    getRecentLog(cwd, 50, headRef),
   ])
 
   const resultsSummary = results

--- a/src/lib/finalize.ts
+++ b/src/lib/finalize.ts
@@ -21,6 +21,8 @@ export interface FinalizeContext {
   changedFiles: string[]
   riskAssessmentEnabled: boolean
   cwd: string
+  /** Main project root (differs from cwd when run used a worktree). */
+  projectRoot?: string
 }
 
 export interface FinalizeResult {
@@ -37,6 +39,7 @@ export async function buildFinalizeContext(
   runDir: string,
   state: RunState,
   config: ProgramConfig,
+  projectRoot?: string,
 ): Promise<FinalizeContext> {
   const [results, changedFiles] = await Promise.all([
     readAllResults(runDir),
@@ -55,6 +58,7 @@ export async function buildFinalizeContext(
     changedFiles,
     riskAssessmentEnabled: config.finalize_risk_assessment !== false,
     cwd,
+    projectRoot: projectRoot !== cwd ? projectRoot : undefined,
   }
 }
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -50,11 +50,54 @@ export class DirtyWorkingTreeError extends Error {
   }
 }
 
+function isOnlyAutoAutoGitignorePatch(diff: string): boolean {
+  if (!diff.trim()) return true
+
+  for (const line of diff.split("\n")) {
+    if (
+      line.startsWith("diff --git") ||
+      line.startsWith("index ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("+++ ") ||
+      line.startsWith("@@")
+    ) {
+      continue
+    }
+
+    if ((line.startsWith("+") || line.startsWith("-")) && line.slice(1).trim() !== ".autoauto/") {
+      return false
+    }
+  }
+
+  return true
+}
+
+async function isOnlyAutoAutoGitignoreChange(cwd: string): Promise<boolean> {
+  const [unstaged, staged] = await Promise.all([
+    $`git diff -- .gitignore`.cwd(cwd).text(),
+    $`git diff --cached -- .gitignore`.cwd(cwd).text(),
+  ])
+
+  return isOnlyAutoAutoGitignorePatch(unstaged) && isOnlyAutoAutoGitignorePatch(staged)
+}
+
 export async function isWorkingTreeClean(cwd: string): Promise<boolean> {
   const lines = (await $`git status --porcelain`.cwd(cwd).text()).trim()
   if (!lines) return true
-  // Ignore autoauto-owned files (measurement PID/log, diagnostics) that live in the worktree
-  const significant = lines.split("\n").filter((l) => !/ \.autoauto-/.test(l))
+  const allowAutoAutoGitignore = lines.includes(".gitignore")
+    ? await isOnlyAutoAutoGitignoreChange(cwd)
+    : false
+  const significant: string[] = []
+
+  for (const line of lines.split("\n")) {
+    if (!line || / \.autoauto-/.test(line)) continue
+
+    const path = line.slice(3).trim()
+    if (path === ".gitignore" && allowAutoAutoGitignore) continue
+
+    significant.push(line)
+  }
+
   return significant.length === 0
 }
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -20,8 +20,9 @@ export async function getFullSha(cwd: string): Promise<string> {
   return (await $`git rev-parse HEAD`.cwd(cwd).text()).trim()
 }
 
-export async function getRecentLog(cwd: string, count?: number): Promise<string> {
-  return (await $`git log --oneline --decorate -n ${String(count ?? 10)}`.cwd(cwd).text()).trim()
+export async function getRecentLog(cwd: string, count?: number, ref?: string): Promise<string> {
+  const args = ref ? [ref] : []
+  return (await $`git log ${args} --oneline --decorate -n ${String(count ?? 10)}`.cwd(cwd).text()).trim()
 }
 
 /** Resets HEAD to the given SHA, discarding all changes. Primary discard mechanism for failed experiments. */

--- a/src/lib/mcp-agent-sessions.ts
+++ b/src/lib/mcp-agent-sessions.ts
@@ -1,0 +1,297 @@
+import { mkdir, readdir, rename, unlink } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { getProvider, type AgentProviderID } from "./agent/index.ts"
+import { loadProjectConfig, type EffortLevel, type ModelSlot } from "./config.ts"
+import type { DraftMessage } from "./drafts.ts"
+import { formatToolEvent } from "./tool-events.ts"
+import { getSetupSystemPrompt } from "./system-prompts/index.ts"
+import { getUpdateSystemPrompt } from "./system-prompts/update.ts"
+import { buildUpdateRunContext } from "./run-context.ts"
+import { AUTOAUTO_DIR, getProgramDir, getProjectRoot, loadProgramSummaries } from "./programs.ts"
+
+const MCP_SESSION_DIR = "_mcp_sessions"
+const SESSION_TOOLS = ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+
+export type McpConversationKind = "setup" | "update"
+export type McpSetupMode = "direct" | "analyze"
+
+export interface McpConversationSession {
+  id: string
+  kind: McpConversationKind
+  programSlug: string | null
+  createdAt: string
+  updatedAt: string
+  provider: AgentProviderID
+  model: string
+  effort: EffortLevel
+  systemPrompt: string
+  messages: DraftMessage[]
+  sdkSessionId: string | null
+}
+
+export interface McpConversationTurnResult {
+  assistantMessage: string
+  toolEvents: string[]
+  messages: DraftMessage[]
+  sessionId: string
+}
+
+interface SessionModelOverrides {
+  provider?: AgentProviderID
+  model?: string
+  effort?: EffortLevel
+}
+
+async function getSessionDir(cwd: string): Promise<string> {
+  const root = await getProjectRoot(cwd)
+  return join(root, AUTOAUTO_DIR, MCP_SESSION_DIR)
+}
+
+async function getSessionPath(cwd: string, sessionId: string): Promise<string> {
+  return join(await getSessionDir(cwd), `${sessionId}.json`)
+}
+
+async function saveSession(cwd: string, session: McpConversationSession): Promise<void> {
+  const dir = await getSessionDir(cwd)
+  await mkdir(dir, { recursive: true })
+  const path = await getSessionPath(cwd, session.id)
+  const tmpPath = `${path}.tmp`
+  await Bun.write(tmpPath, JSON.stringify(session, null, 2) + "\n")
+  await rename(tmpPath, path)
+}
+
+export async function loadSession(cwd: string, sessionId: string): Promise<McpConversationSession | null> {
+  try {
+    return await Bun.file(await getSessionPath(cwd, sessionId)).json() as McpConversationSession
+  } catch {
+    return null
+  }
+}
+
+export async function listSessions(cwd: string): Promise<McpConversationSession[]> {
+  const dir = await getSessionDir(cwd)
+  let entries: string[]
+  try {
+    entries = await readdir(dir)
+  } catch {
+    return []
+  }
+
+  const sessions = (
+    await Promise.all(
+      entries
+        .filter((entry) => entry.endsWith(".json"))
+        .map(async (entry) => loadSession(cwd, entry.slice(0, -5))),
+    )
+  ).filter((session): session is McpConversationSession => session !== null)
+
+  return sessions.toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+}
+
+export async function deleteSession(cwd: string, sessionId: string): Promise<void> {
+  await unlink(await getSessionPath(cwd, sessionId)).catch(() => {})
+}
+
+function buildTranscriptSystemPrompt(systemPrompt: string, messages: DraftMessage[]): string {
+  if (messages.length === 0) return systemPrompt
+
+  const transcript = messages
+    .map((message) => `${message.role === "user" ? "User" : "Assistant"}: ${message.content}`)
+    .join("\n\n")
+
+  return [
+    systemPrompt,
+    "",
+    "---",
+    "Here is the conversation so far from a previous session. Continue from where we left off:",
+    "",
+    transcript,
+    "---",
+  ].join("\n")
+}
+
+async function resolveSupportModel(cwd: string, overrides: SessionModelOverrides): Promise<ModelSlot> {
+  const root = await getProjectRoot(cwd)
+  const projectConfig = await loadProjectConfig(root)
+  const supportModel = projectConfig.supportModel
+  return {
+    provider: overrides.provider ?? supportModel.provider,
+    model: overrides.model ?? supportModel.model,
+    effort: overrides.effort ?? supportModel.effort,
+  }
+}
+
+async function ensureReferenceFile(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await Bun.write(path, content)
+}
+
+async function runTurn(cwd: string, session: McpConversationSession, userMessage: string): Promise<McpConversationTurnResult> {
+  const message = userMessage.trim()
+  if (!message) throw new Error("Message cannot be empty.")
+
+  session.messages.push({ role: "user", content: message })
+  session.updatedAt = new Date().toISOString()
+  await saveSession(cwd, session)
+
+  const canResumeClaude = session.provider === "claude" && Boolean(session.sdkSessionId)
+  const provider = getProvider(session.provider)
+  const agentSession = provider.createSession({
+    systemPrompt: canResumeClaude
+      ? session.systemPrompt
+      : buildTranscriptSystemPrompt(session.systemPrompt, session.messages.slice(0, -1)),
+    tools: SESSION_TOOLS,
+    allowedTools: SESSION_TOOLS,
+    cwd,
+    model: session.model,
+    effort: session.effort,
+    resumeSessionId: canResumeClaude ? session.sdkSessionId ?? undefined : undefined,
+  })
+
+  const toolEvents: string[] = []
+  let assistantMessage = ""
+  let turnError: string | null = null
+
+  try {
+    agentSession.pushMessage(message)
+    agentSession.endInput()
+
+    for await (const event of agentSession) {
+      if (agentSession.sessionId) session.sdkSessionId = agentSession.sessionId
+
+      switch (event.type) {
+        case "text_delta":
+          assistantMessage += event.text
+          break
+        case "tool_use":
+          toolEvents.push(formatToolEvent(event.tool, event.input ?? {}))
+          break
+        case "assistant_complete":
+          assistantMessage = event.text
+          break
+        case "error":
+          turnError = event.error
+          break
+        case "result":
+          if (!event.success) {
+            turnError = event.error ?? "Agent turn failed."
+          }
+          break
+      }
+    }
+  } finally {
+    agentSession.close()
+  }
+
+  if (agentSession.sessionId) session.sdkSessionId = agentSession.sessionId
+
+  if (turnError) {
+    session.updatedAt = new Date().toISOString()
+    await saveSession(cwd, session)
+    throw new Error(turnError)
+  }
+
+  const finalAssistantMessage = assistantMessage.trim()
+  if (finalAssistantMessage) {
+    session.messages.push({ role: "assistant", content: finalAssistantMessage })
+  }
+  session.updatedAt = new Date().toISOString()
+  await saveSession(cwd, session)
+
+  return {
+    assistantMessage: finalAssistantMessage,
+    toolEvents,
+    messages: session.messages,
+    sessionId: session.id,
+  }
+}
+
+export async function startSetupSession(
+  cwd: string,
+  options: SessionModelOverrides & { mode: McpSetupMode; message?: string; focus?: string },
+): Promise<{
+  session: McpConversationSession
+  firstTurn: McpConversationTurnResult | null
+}> {
+  const root = await getProjectRoot(cwd)
+  const existingPrograms = await loadProgramSummaries(root)
+  const prompt = getSetupSystemPrompt(root, existingPrograms)
+  await ensureReferenceFile(prompt.referencePath, prompt.referenceContent)
+
+  const model = await resolveSupportModel(root, options)
+  const now = new Date().toISOString()
+  const session: McpConversationSession = {
+    id: crypto.randomUUID(),
+    kind: "setup",
+    programSlug: null,
+    createdAt: now,
+    updatedAt: now,
+    provider: model.provider,
+    model: model.model,
+    effort: model.effort,
+    systemPrompt: prompt.systemPrompt,
+    messages: [],
+    sdkSessionId: null,
+  }
+  await saveSession(root, session)
+
+  const firstMessage = options.mode === "analyze"
+    ? (options.focus?.trim()
+        ? `What could I optimize in this codebase, focusing on ${options.focus.trim()}?`
+        : "What could I optimize in this codebase?")
+    : options.message?.trim() ?? ""
+
+  return {
+    session,
+    firstTurn: firstMessage ? await runTurn(root, session, firstMessage) : null,
+  }
+}
+
+export async function startUpdateSession(
+  cwd: string,
+  programSlug: string,
+  options: SessionModelOverrides = {},
+): Promise<{
+  session: McpConversationSession
+  firstTurn: McpConversationTurnResult
+}> {
+  const root = await getProjectRoot(cwd)
+  const programDir = getProgramDir(root, programSlug)
+  const prompt = await getUpdateSystemPrompt(root, programSlug, programDir)
+  await ensureReferenceFile(prompt.referencePath, prompt.referenceContent)
+
+  const model = await resolveSupportModel(root, options)
+  const now = new Date().toISOString()
+  const session: McpConversationSession = {
+    id: crypto.randomUUID(),
+    kind: "update",
+    programSlug,
+    createdAt: now,
+    updatedAt: now,
+    provider: model.provider,
+    model: model.model,
+    effort: model.effort,
+    systemPrompt: prompt.systemPrompt,
+    messages: [],
+    sdkSessionId: null,
+  }
+  await saveSession(root, session)
+
+  const initialContext = await buildUpdateRunContext(programDir)
+
+  return {
+    session,
+    firstTurn: await runTurn(root, session, initialContext),
+  }
+}
+
+export async function sendSessionMessage(
+  cwd: string,
+  sessionId: string,
+  message: string,
+): Promise<McpConversationTurnResult> {
+  const root = await getProjectRoot(cwd)
+  const session = await loadSession(root, sessionId)
+  if (!session) throw new Error(`Session "${sessionId}" not found.`)
+  return runTurn(root, session, message)
+}

--- a/src/lib/self-command-format.ts
+++ b/src/lib/self-command-format.ts
@@ -1,0 +1,11 @@
+import { getSelfCommand } from "./self-command.ts"
+
+function shellQuote(arg: string): string {
+  if (/^[a-zA-Z0-9_./:-]+$/.test(arg)) return arg
+  return `'${arg.replace(/'/g, `'\"'\"'`)}'`
+}
+
+export function formatSelfCommand(subcommand: string): string {
+  const command = getSelfCommand(subcommand)
+  return [command.command, ...command.args].map(shellQuote).join(" ")
+}

--- a/src/lib/self-command-format.ts
+++ b/src/lib/self-command-format.ts
@@ -5,7 +5,7 @@ function shellQuote(arg: string): string {
   return `'${arg.replace(/'/g, `'"'"'`)}'`
 }
 
-export function formatSelfCommand(subcommand: string): string {
+export function formatSelfCommand(subcommand: string, args: string[] = []): string {
   const command = getSelfCommand(subcommand)
-  return [command.command, ...command.args].map(shellQuote).join(" ")
+  return [command.command, ...command.args, ...args].map(shellQuote).join(" ")
 }

--- a/src/lib/self-command-format.ts
+++ b/src/lib/self-command-format.ts
@@ -2,7 +2,7 @@ import { getSelfCommand } from "./self-command.ts"
 
 function shellQuote(arg: string): string {
   if (/^[a-zA-Z0-9_./:-]+$/.test(arg)) return arg
-  return `'${arg.replace(/'/g, `'\"'\"'`)}'`
+  return `'${arg.replace(/'/g, `'"'"'`)}'`
 }
 
 export function formatSelfCommand(subcommand: string): string {

--- a/src/lib/self-command.ts
+++ b/src/lib/self-command.ts
@@ -1,0 +1,12 @@
+import { basename, dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const SOURCE_ENTRYPOINT = join(dirname(fileURLToPath(import.meta.url)), "..", "index.tsx")
+
+export function getSelfCommand(subcommand: string): { command: string; args: string[] } {
+  const execPath = process.execPath
+  if (basename(execPath).toLowerCase() === "bun") {
+    return { command: execPath, args: [SOURCE_ENTRYPOINT, subcommand] }
+  }
+  return { command: execPath, args: [subcommand] }
+}

--- a/src/lib/self-command.ts
+++ b/src/lib/self-command.ts
@@ -5,7 +5,8 @@ const SOURCE_ENTRYPOINT = join(dirname(fileURLToPath(import.meta.url)), "..", "i
 
 export function getSelfCommand(subcommand: string): { command: string; args: string[] } {
   const execPath = process.execPath
-  if (basename(execPath).toLowerCase() === "bun") {
+  const execName = basename(execPath).toLowerCase()
+  if (execName === "bun" || execName === "bun.exe") {
     return { command: execPath, args: [SOURCE_ENTRYPOINT, subcommand] }
   }
   return { command: execPath, args: [subcommand] }

--- a/src/lib/system-prompts/experiment.ts
+++ b/src/lib/system-prompts/experiment.ts
@@ -17,9 +17,9 @@ Keep these notes factual and short. Do not edit any ideas backlog file yourself;
 ` : ""
   const exitSectionNumber = useIdeasBacklog ? "7" : "6"
 
-  return `You are an AutoAuto Experiment Agent — one experiment in an autonomous optimization loop. An external orchestrator handles measurement, keep/discard decisions, and loop control. Your job: analyze, plan ONE targeted optimization, implement it, validate it, and commit.
+  return `You are an AutoAuto Experiment Agent — one experiment in an autonomous optimization loop. You start fresh each time with no memory of previous experiments — your entire history is in the context provided below. Read it carefully before acting. An external orchestrator handles measurement, keep/discard decisions, and loop control. Your job: analyze, plan ONE targeted optimization, implement it, validate it, and commit.
 
-For maximum efficiency, whenever you need to perform multiple independent operations (reading several files, running parallel checks, etc.), invoke all relevant tools simultaneously in a single response rather than sequentially. Each sequential tool call is a full API round-trip — parallelizing independent calls dramatically reduces experiment time.
+Parallelize independent tool calls (reads, searches) in a single response — each sequential call is a wasted round-trip.
 
 ${programMd}
 
@@ -31,6 +31,7 @@ ${programMd}
 - Study results.tsv carefully: which approaches were kept? Which were discarded? What patterns emerge?
 - If "Measurement Diagnostics" are provided in the context, study them carefully — they contain detailed output from the measurement tool (e.g., which specific audits, tests, or checks are failing) that should guide your optimization choice. Do NOT guess from code inspection when diagnostics are available.
 - Review the 'Recently Discarded Experiments' section above to understand WHY past experiments failed — don't just note that they failed.
+- Read the Ideas Backlog carefully if present. The "avoid" items are hard-won lessons from previous experiments — repeating them wastes a cycle. The "next" suggestions are your best starting points. If a suggestion aligns with what you see in the code, prefer it over generating your own ideas from scratch.
 - Identify the actual bottleneck or opportunity. A targeted change to the real bottleneck beats a shotgun approach.
 - If you're experiment #1, spend extra time reading the codebase. Later experiments should build on what the history tells you.
 - If you have NOT committed by ~70% of your turn budget, either commit what you have or exit cleanly. Do NOT keep exploring — a no-commit wastes the entire experiment.

--- a/src/lib/system-prompts/finalize.ts
+++ b/src/lib/system-prompts/finalize.ts
@@ -2,7 +2,7 @@ import type { FinalizeContext } from "../finalize.ts"
 
 /** Returns the system prompt for the conversational finalize agent. */
 export function getFinalizeSystemPrompt(context: FinalizeContext): string {
-  const { branchName, originalBranch, originalBaselineSha, riskAssessmentEnabled } = context
+  const { branchName, originalBranch, originalBaselineSha, riskAssessmentEnabled, projectRoot, cwd } = context
 
   const branchOptions = [
     `1. **Keep on current run branch** (\`${branchName}\`) — changes stay as-is`,
@@ -94,6 +94,9 @@ Based on the user's choice:
   2. Cherry-pick the kept (non-excluded) commits in order
   3. If conflicts arise, resolve them and explain what you did
   4. Confirm the final state
+${projectRoot ? `
+**Worktree awareness:** This run used a git worktree. Your working directory is \`${cwd}\` (the worktree), and the main project checkout is at \`${projectRoot}\`. If you need to operate on a branch that is already checked out in the main worktree (e.g. the original branch), \`cd\` to \`${projectRoot}\` and cherry-pick there instead of trying to check it out here. Use \`git worktree list\` to see which branches are checked out where.
+` : ""}
 
 ### Step 6: Completion
 
@@ -114,9 +117,11 @@ Replace BRANCH_NAME with the actual branch name where the code ended up.
 - \`git reset --hard\` on main or master branches
 - \`git branch -D\` (force-delete branches)
 - \`git push --force\`
-- Any command that modifies files outside the working directory
+- Any command that modifies files outside the repository${projectRoot ? `
 
-Only operate within the provided working directory. All git operations should be local only.
+Only operate within the working directory (\`${cwd}\`) or the main project checkout (\`${projectRoot}\`). All git operations should be local only.` : `
+
+Only operate within the provided working directory. All git operations should be local only.`}
 
 ## Style
 

--- a/src/lib/system-prompts/setup.ts
+++ b/src/lib/system-prompts/setup.ts
@@ -1,8 +1,10 @@
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { getProgramsDir, type ProgramSummary } from "../programs.ts"
+import { formatSelfCommand } from "../self-command-format.ts"
 
 const VALIDATE_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "..", "validate-measurement.ts")
+const VALIDATE_COMMAND = formatSelfCommand("__validate_measurement")
 
 export interface SetupPromptResult {
   systemPrompt: string
@@ -93,6 +95,7 @@ This file contains step-by-step conversation guidance, artifact formats, saving 
 **Paths:**
 - Programs directory: ${programsDir}
 - Validation script: ${VALIDATE_SCRIPT}
+- Validation command: ${VALIDATE_COMMAND}
 
 ## Step-by-Step Guidance
 

--- a/src/lib/system-prompts/update.ts
+++ b/src/lib/system-prompts/update.ts
@@ -1,8 +1,10 @@
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { getProgramsDir } from "../programs.ts"
+import { formatSelfCommand } from "../self-command-format.ts"
 
 const VALIDATE_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "..", "validate-measurement.ts")
+const VALIDATE_COMMAND = formatSelfCommand("__validate_measurement")
 
 export interface UpdatePromptResult {
   systemPrompt: string
@@ -105,6 +107,7 @@ This file contains validation procedures and artifact format reference for the A
 - Programs directory: ${programsDir}
 - Program directory: ${programDir}
 - Validation script: ${VALIDATE_SCRIPT}
+- Validation command: ${VALIDATE_COMMAND}
 
 ## Measurement Validation
 
@@ -114,7 +117,7 @@ After modifying measure.sh, build.sh, or config.json, ALWAYS validate measuremen
 
 Run this exact command via Bash:
 \`\`\`bash
-bun run ${VALIDATE_SCRIPT} ${programDir}/measure.sh ${programDir}/config.json 5
+${VALIDATE_COMMAND} ${programDir}/measure.sh ${programDir}/config.json 5
 \`\`\`
 
 The validation script:

--- a/src/lib/system-prompts/update.ts
+++ b/src/lib/system-prompts/update.ts
@@ -4,7 +4,6 @@ import { getProgramsDir } from "../programs.ts"
 import { formatSelfCommand } from "../self-command-format.ts"
 
 const VALIDATE_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "..", "validate-measurement.ts")
-const VALIDATE_COMMAND = formatSelfCommand("__validate_measurement")
 
 export interface UpdatePromptResult {
   systemPrompt: string
@@ -23,6 +22,11 @@ export async function getUpdateSystemPrompt(
 ): Promise<UpdatePromptResult> {
   const programsDir = getProgramsDir(cwd)
   const referencePath = join(cwd, ".autoauto", "update-reference.md")
+  const validateProgramCommand = formatSelfCommand("__validate_measurement", [
+    join(programDir, "measure.sh"),
+    join(programDir, "config.json"),
+    "5",
+  ])
 
   const [programMd, measureSh, configJson, buildSh] = await Promise.all([
     Bun.file(join(programDir, "program.md")).text().catch(() => "(not found)"),
@@ -107,7 +111,7 @@ This file contains validation procedures and artifact format reference for the A
 - Programs directory: ${programsDir}
 - Program directory: ${programDir}
 - Validation script: ${VALIDATE_SCRIPT}
-- Validation command: ${VALIDATE_COMMAND}
+- Validation command: ${validateProgramCommand}
 
 ## Measurement Validation
 
@@ -117,7 +121,7 @@ After modifying measure.sh, build.sh, or config.json, ALWAYS validate measuremen
 
 Run this exact command via Bash:
 \`\`\`bash
-${VALIDATE_COMMAND} ${programDir}/measure.sh ${programDir}/config.json 5
+${validateProgramCommand}
 \`\`\`
 
 The validation script:

--- a/src/lib/validate-measurement.ts
+++ b/src/lib/validate-measurement.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /* eslint-disable no-console, no-await-in-loop */
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { $ } from "bun"
 import { validateProgramConfig, type ProgramConfig } from "./programs.ts"
@@ -164,7 +164,7 @@ export async function startValidateMeasurement(args = process.argv.slice(2)) {
 
   let config: ProgramConfig
   try {
-    config = validateProgramConfig(JSON.parse(readFileSync(configJsonPath, "utf-8")))
+    config = validateProgramConfig(await Bun.file(configJsonPath).json())
   } catch (err) {
     console.log(JSON.stringify({ success: false, error: `Failed to read config.json: ${err}` }))
     process.exit(0)

--- a/src/lib/validate-measurement.ts
+++ b/src/lib/validate-measurement.ts
@@ -58,28 +58,6 @@ interface ValidationOutput {
 
 // --- Input Parsing ---
 
-const [measureShPath, configJsonPath, runsStr] = process.argv.slice(2)
-
-if (!measureShPath || !configJsonPath) {
-  console.error("Usage: validate-measurement.ts <measure_sh> <config_json> [runs]")
-  process.exit(1)
-}
-
-const numRuns = parseInt(runsStr || "5", 10)
-// Resolve cwd from measure.sh's location — go up from .autoauto/programs/<slug>/
-// to the project root.
-const projectRoot = dirname(dirname(dirname(dirname(measureShPath))))
-
-// --- Config Parsing ---
-
-let config: ProgramConfig
-try {
-  config = validateProgramConfig(JSON.parse(readFileSync(configJsonPath, "utf-8")))
-} catch (err) {
-  console.log(JSON.stringify({ success: false, error: `Failed to read config.json: ${err}` }))
-  process.exit(0)
-}
-
 // --- Measurement Execution ---
 
 const VALIDATION_TIMEOUT_MS = 300_000 // 5 min — generous for setup validation
@@ -173,7 +151,25 @@ async function createValidationWorktree(root: string): Promise<string> {
   return worktreePath
 }
 
-async function main() {
+export async function startValidateMeasurement(args = process.argv.slice(2)) {
+  const [measureShPath, configJsonPath, runsStr] = args
+
+  if (!measureShPath || !configJsonPath) {
+    console.error("Usage: validate-measurement.ts <measure_sh> <config_json> [runs]")
+    process.exit(1)
+  }
+
+  const numRuns = parseInt(runsStr || "5", 10)
+  const projectRoot = dirname(dirname(dirname(dirname(measureShPath))))
+
+  let config: ProgramConfig
+  try {
+    config = validateProgramConfig(JSON.parse(readFileSync(configJsonPath, "utf-8")))
+  } catch (err) {
+    console.log(JSON.stringify({ success: false, error: `Failed to read config.json: ${err}` }))
+    process.exit(0)
+  }
+
   const buildShPath = join(dirname(measureShPath), "build.sh")
 
   process.stderr.write("Creating validation worktree...\n")
@@ -187,7 +183,7 @@ async function main() {
   process.stderr.write(`Worktree: ${worktreePath}\n`)
 
   try {
-    await runInWorktree(worktreePath, buildShPath)
+    await runInWorktree(worktreePath, buildShPath, measureShPath, numRuns, config)
   } finally {
     process.stderr.write("Cleaning up validation worktree...\n")
     await removeWorktree(projectRoot, worktreePath)
@@ -197,6 +193,9 @@ async function main() {
 async function runInWorktree(
   cwd: string,
   buildShPath: string,
+  measureShPath: string,
+  numRuns: number,
+  config: ProgramConfig,
 ) {
   const hasBuildScript = existsSync(buildShPath)
   const buildResult = hasBuildScript
@@ -331,6 +330,8 @@ async function runInWorktree(
   console.log(JSON.stringify(output, null, 2))
 }
 
-main().catch((err) => {
-  console.log(JSON.stringify({ success: false, error: String(err) }))
-})
+if (import.meta.main) {
+  startValidateMeasurement().catch((err) => {
+    console.log(JSON.stringify({ success: false, error: String(err) }))
+  })
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -65,8 +65,6 @@ function resolveCwd(): string {
   return process.cwd()
 }
 
-const CWD = resolveCwd()
-
 const VALIDATE_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "lib", "validate-measurement.ts")
 
 /** Reusable slug schema — prevents path traversal via names like "../../etc" */
@@ -111,40 +109,42 @@ async function resolveRunDir(
   return { runDir: latest.run_dir, runId: latest.run_id }
 }
 
-async function resolveProgram(name: string): Promise<{ root: string; programDir: string; programConfig: ProgramConfig }> {
-  const root = await getProjectRoot(CWD)
-  const programDir = getProgramDir(root, name)
-  try {
-    const programConfig = await loadProgramConfig(programDir)
-    return { root, programDir, programConfig }
-  } catch {
-    throw new Error(`Program '${name}' not found.`)
-  }
-}
-
 async function writeScript(path: string, content: string): Promise<void> {
   await Bun.write(path, content)
   await chmod(path, 0o755)
 }
 
-// ---------------------------------------------------------------------------
-// Server
-// ---------------------------------------------------------------------------
-
 const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json()
 
-const server = new McpServer(
-  { name: "autoauto", version: pkg.version },
-  {
-    capabilities: { logging: {} },
-    instructions: [
-      "AutoAuto manages autoresearch programs — autonomous experiment loops that optimize a single metric on any codebase.",
-      "Setup workflow: (1) get_setup_guide to learn artifact formats, (2) list_programs to check for duplicates, (3) create_program to write all files, (4) validate_measurement to verify stability.",
-      "Run workflow: (1) start_run to launch an experiment loop, (2) get_run_status to check progress, (3) get_run_results to see experiment outcomes, (4) get_experiment_log for agent output on a specific experiment, (5) stop_run to stop when satisfied, (6) get_run_summary for a post-run report.",
-      "Management: list_programs for overview, get_program to inspect, update_program to modify, delete_program to remove. Use list_runs to see run history, update_run_limit to change max experiments mid-run.",
-    ].join("\n"),
-  },
-)
+// ---------------------------------------------------------------------------
+// Server factory
+// ---------------------------------------------------------------------------
+
+/** Create an MCP server instance bound to the given project root. */
+export function createMcpServer(cwd: string): McpServer {
+  async function resolveProgram(name: string): Promise<{ root: string; programDir: string; programConfig: ProgramConfig }> {
+    const root = await getProjectRoot(cwd)
+    const programDir = getProgramDir(root, name)
+    try {
+      const programConfig = await loadProgramConfig(programDir)
+      return { root, programDir, programConfig }
+    } catch {
+      throw new Error(`Program '${name}' not found.`)
+    }
+  }
+
+  const server = new McpServer(
+    { name: "autoauto", version: pkg.version },
+    {
+      capabilities: { logging: {} },
+      instructions: [
+        "AutoAuto manages autoresearch programs — autonomous experiment loops that optimize a single metric on any codebase.",
+        "Setup workflow: (1) get_setup_guide to learn artifact formats, (2) list_programs to check for duplicates, (3) create_program to write all files, (4) validate_measurement to verify stability.",
+        "Run workflow: (1) start_run to launch an experiment loop, (2) get_run_status to check progress, (3) get_run_results to see experiment outcomes, (4) get_experiment_log for agent output on a specific experiment, (5) stop_run to stop when satisfied, (6) get_run_summary for a post-run report.",
+        "Management: list_programs for overview, get_program to inspect, update_program to modify, delete_program to remove. Use list_runs to see run history, update_run_limit to change max experiments mid-run.",
+      ].join("\n"),
+    },
+  )
 
 // ---------------------------------------------------------------------------
 // Tool: list_programs
@@ -160,11 +160,11 @@ server.registerTool(
     annotations: { readOnlyHint: true },
   },
   async () => {
-    const root = await getProjectRoot(CWD)
-    const programs = await listPrograms(CWD)
+    const root = await getProjectRoot(cwd)
+    const programs = await listPrograms(cwd)
     if (programs.length === 0) return text("No programs found.")
 
-    const summaries = await loadProgramSummaries(CWD)
+    const summaries = await loadProgramSummaries(cwd)
     const summaryMap = new Map(summaries.map((s) => [s.slug, s.goal]))
 
     const result = await Promise.all(
@@ -200,7 +200,7 @@ server.registerTool(
     annotations: { readOnlyHint: true },
   },
   async ({ name }) => {
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
 
     let config: ProgramConfig
@@ -244,7 +244,7 @@ server.registerTool(
     annotations: { readOnlyHint: true },
   },
   async () => {
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programsDir = getProgramsDir(root)
 
     const guide = `# AutoAuto Program Setup Guide
@@ -459,7 +459,7 @@ server.registerTool(
     annotations: { destructiveHint: false, idempotentHint: false },
   },
   async ({ name, program_md, measure_sh, build_sh, config }) => {
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
 
     // Check for existing program
@@ -477,7 +477,7 @@ server.registerTool(
     }
 
     // Ensure .autoauto directory and .gitignore
-    await ensureAutoAutoDir(CWD)
+    await ensureAutoAutoDir(cwd)
 
     // Create program directory
     await mkdir(programDir, { recursive: true })
@@ -522,7 +522,7 @@ server.registerTool(
     annotations: { destructiveHint: false, idempotentHint: true },
   },
   async ({ name, program_md, measure_sh, build_sh, config }) => {
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
 
     if (!(await Bun.file(join(programDir, "config.json")).exists())) {
@@ -587,7 +587,7 @@ server.registerTool(
       return errorResult("Deletion requires confirm=true.")
     }
 
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
 
     if (!(await Bun.file(join(programDir, "config.json")).exists())) {
@@ -624,7 +624,7 @@ server.registerTool(
     }),
   },
   async ({ name, runs }) => {
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
     const measureSh = join(programDir, "measure.sh")
     const configJson = join(programDir, "config.json")
@@ -949,7 +949,7 @@ server.registerTool(
     annotations: { readOnlyHint: true },
   },
   async ({ name, experiment_number, run_id }) => {
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
 
     if (!(await Bun.file(join(programDir, "config.json")).exists())) {
@@ -1003,7 +1003,7 @@ server.registerTool(
     }),
   },
   async ({ name, abort }) => {
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
 
     const active = await findActiveRun(programDir)
@@ -1063,7 +1063,7 @@ server.registerTool(
     }),
   },
   async ({ name, max_experiments }) => {
-    const root = await getProjectRoot(CWD)
+    const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
 
     const active = await findActiveRun(programDir)
@@ -1170,15 +1170,20 @@ server.registerTool(
   },
 )
 
+  return server
+}
+
 // ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------
 
 export async function startMcpServer() {
+  const cwd = resolveCwd()
+  const server = createMcpServer(cwd)
   const transport = new StdioServerTransport()
   await server.connect(transport)
   // All logging must go to stderr — stdout is the MCP protocol channel
-  console.error(`AutoAuto MCP server running (cwd: ${CWD})`)
+  console.error(`AutoAuto MCP server running (cwd: ${cwd})`)
 }
 
 // Direct execution

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -38,14 +38,25 @@ import {
   type RunState,
 } from "./lib/run.ts"
 import {
-  spawnDaemon,
-  getDaemonStatus,
-  sendStop,
-  sendAbort,
-  forceKillDaemon,
-  findActiveRun,
-  updateMaxExperiments,
+  spawnDaemon as _spawnDaemon,
+  getDaemonStatus as _getDaemonStatus,
+  sendStop as _sendStop,
+  sendAbort as _sendAbort,
+  forceKillDaemon as _forceKillDaemon,
+  findActiveRun as _findActiveRun,
+  updateMaxExperiments as _updateMaxExperiments,
 } from "./lib/daemon-client.ts"
+
+/** Daemon function overrides for testing (avoids process-wide mock.module). */
+export interface McpDaemonDeps {
+  spawnDaemon: typeof _spawnDaemon
+  getDaemonStatus: typeof _getDaemonStatus
+  sendStop: typeof _sendStop
+  sendAbort: typeof _sendAbort
+  forceKillDaemon: typeof _forceKillDaemon
+  findActiveRun: typeof _findActiveRun
+  updateMaxExperiments: typeof _updateMaxExperiments
+}
 import {
   loadProjectConfig,
   saveProjectConfig,
@@ -143,8 +154,16 @@ async function writeScript(path: string, content: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 /** Create an MCP server instance bound to the given project root. */
-export function createMcpServer(cwd: string): McpServer {
+export function createMcpServer(cwd: string, daemonDeps?: Partial<McpDaemonDeps>): McpServer {
   registerDefaultProviders()
+
+  const spawnDaemon = daemonDeps?.spawnDaemon ?? _spawnDaemon
+  const getDaemonStatus = daemonDeps?.getDaemonStatus ?? _getDaemonStatus
+  const sendStop = daemonDeps?.sendStop ?? _sendStop
+  const sendAbort = daemonDeps?.sendAbort ?? _sendAbort
+  const forceKillDaemon = daemonDeps?.forceKillDaemon ?? _forceKillDaemon
+  const findActiveRun = daemonDeps?.findActiveRun ?? _findActiveRun
+  const updateMaxExperiments = daemonDeps?.updateMaxExperiments ?? _updateMaxExperiments
 
   async function resolveProgram(name: string): Promise<{ root: string; programDir: string; programConfig: ProgramConfig }> {
     const root = await getProjectRoot(cwd)

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -14,8 +14,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod"
-import { join, dirname } from "node:path"
-import { fileURLToPath } from "node:url"
+import { join } from "node:path"
 import { mkdir, chmod } from "node:fs/promises"
 import {
   listPrograms,
@@ -49,11 +48,27 @@ import {
 } from "./lib/daemon-client.ts"
 import {
   loadProjectConfig,
+  saveProjectConfig,
+  NOTIFICATION_PRESET_IDS,
+  PROVIDER_CHOICES,
+  type ProjectConfig,
   type ModelSlot,
 } from "./lib/config.ts"
 import { streamLogName } from "./lib/daemon-callbacks.ts"
 import { formatRunDuration, formatChangePct } from "./lib/format.ts"
 import { generateSummaryReport, saveFinalizeReport } from "./lib/finalize.ts"
+import { getSelfCommand } from "./lib/self-command.ts"
+import {
+  deleteSession as deleteAgentSession,
+  listSessions as listAgentSessions,
+  loadSession as loadAgentSession,
+  sendSessionMessage,
+  startSetupSession,
+  startUpdateSession,
+} from "./lib/mcp-agent-sessions.ts"
+import { getProvider } from "./lib/agent/index.ts"
+import { registerDefaultProviders } from "./lib/agent/default-providers.ts"
+import { AUTOAUTO_VERSION } from "./version.ts"
 
 // ---------------------------------------------------------------------------
 // CWD resolution
@@ -64,8 +79,6 @@ function resolveCwd(): string {
   if (idx !== -1 && process.argv[idx + 1]) return process.argv[idx + 1]
   return process.cwd()
 }
-
-const VALIDATE_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "lib", "validate-measurement.ts")
 
 /** Reusable slug schema — prevents path traversal via names like "../../etc" */
 const SlugSchema = z.string().min(1).regex(/^[a-z0-9-]+$/, "Must be lowercase letters, numbers, and hyphens only")
@@ -84,6 +97,17 @@ function jsonText(obj: unknown) {
 
 function errorResult(msg: string) {
   return { content: [{ type: "text" as const, text: msg }], isError: true as const }
+}
+
+function getProviderOrError(provider: typeof PROVIDER_CHOICES[number]) {
+  try {
+    return { provider: getProvider(provider), error: null }
+  } catch (err) {
+    return {
+      provider: null,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
 }
 
 async function readFileOrNull(path: string): Promise<string | null> {
@@ -114,14 +138,14 @@ async function writeScript(path: string, content: string): Promise<void> {
   await chmod(path, 0o755)
 }
 
-const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json()
-
 // ---------------------------------------------------------------------------
 // Server factory
 // ---------------------------------------------------------------------------
 
 /** Create an MCP server instance bound to the given project root. */
 export function createMcpServer(cwd: string): McpServer {
+  registerDefaultProviders()
+
   async function resolveProgram(name: string): Promise<{ root: string; programDir: string; programConfig: ProgramConfig }> {
     const root = await getProjectRoot(cwd)
     const programDir = getProgramDir(root, name)
@@ -134,7 +158,7 @@ export function createMcpServer(cwd: string): McpServer {
   }
 
   const server = new McpServer(
-    { name: "autoauto", version: pkg.version },
+    { name: "autoauto", version: AUTOAUTO_VERSION },
     {
       capabilities: { logging: {} },
       instructions: [
@@ -145,6 +169,171 @@ export function createMcpServer(cwd: string): McpServer {
       ].join("\n"),
     },
   )
+
+const ModelSlotSchema = z.object({
+  provider: z.enum(PROVIDER_CHOICES),
+  model: z.string().min(1),
+  effort: z.enum(["low", "medium", "high", "max"]),
+})
+
+const PartialProjectConfigSchema = z.object({
+  executionModel: ModelSlotSchema.optional(),
+  supportModel: ModelSlotSchema.optional(),
+  executionFallbackModel: z.union([ModelSlotSchema, z.null()]).optional(),
+  ideasBacklogEnabled: z.boolean().optional(),
+  notificationPreset: z.enum(NOTIFICATION_PRESET_IDS).optional(),
+  notificationCommand: z.union([z.string(), z.null()]).optional(),
+})
+
+function mergeProjectConfig(current: ProjectConfig, patch: z.infer<typeof PartialProjectConfigSchema>): ProjectConfig {
+  return {
+    ...current,
+    ...patch,
+    executionModel: patch.executionModel ?? current.executionModel,
+    supportModel: patch.supportModel ?? current.supportModel,
+    executionFallbackModel: patch.executionFallbackModel !== undefined
+      ? patch.executionFallbackModel
+      : current.executionFallbackModel,
+  }
+}
+
+server.registerTool(
+  "get_config",
+  {
+    title: "Get Config",
+    description: "Get the project configuration used for execution, setup/update, fallback, ideas backlog, and notifications.",
+    inputSchema: z.object({}),
+    annotations: { readOnlyHint: true },
+  },
+  async () => {
+    const root = await getProjectRoot(cwd)
+    const config = await loadProjectConfig(root)
+    return jsonText(config)
+  },
+)
+
+server.registerTool(
+  "set_config",
+  {
+    title: "Set Config",
+    description: "Update project configuration fields. Only provided fields are changed.",
+    inputSchema: PartialProjectConfigSchema,
+  },
+  async (patch) => {
+    const root = await getProjectRoot(cwd)
+    const current = await loadProjectConfig(root)
+    const next = mergeProjectConfig(current, patch)
+    await saveProjectConfig(root, next)
+    return jsonText(next)
+  },
+)
+
+server.registerTool(
+  "list_models",
+  {
+    title: "List Models",
+    description: "List available models for one provider or all providers, including the provider default model when available.",
+    inputSchema: z.object({
+      provider: z.enum(PROVIDER_CHOICES).optional().describe("Optional provider filter"),
+      force_refresh: z.boolean().default(false).describe("Ask the provider to refresh model data"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ provider, force_refresh }) => {
+    const root = await getProjectRoot(cwd)
+    const providers = provider ? [provider] as const : PROVIDER_CHOICES
+    const results = await Promise.all(providers.map(async (providerId) => {
+      const resolved = getProviderOrError(providerId)
+      if (!resolved.provider) {
+        return {
+          provider: providerId,
+          available: false,
+          error: resolved.error,
+          default_model: null,
+          models: [],
+        }
+      }
+
+      try {
+        const [models, defaultModel] = await Promise.all([
+          resolved.provider.listModels?.(root, force_refresh) ?? Promise.resolve([]),
+          resolved.provider.getDefaultModel?.(root) ?? Promise.resolve(null),
+        ])
+        return {
+          provider: providerId,
+          available: true,
+          error: null,
+          default_model: defaultModel,
+          models: models.map((model) => ({
+            provider: model.provider,
+            model: model.model,
+            label: model.label,
+            description: model.description ?? null,
+            is_default: model.isDefault ?? false,
+          })),
+        }
+      } catch (err) {
+        return {
+          provider: providerId,
+          available: false,
+          error: err instanceof Error ? err.message : String(err),
+          default_model: null,
+          models: [],
+        }
+      }
+    }))
+
+    return jsonText(provider ? results[0] : results)
+  },
+)
+
+server.registerTool(
+  "check_auth",
+  {
+    title: "Check Auth",
+    description: "Check authentication status for one provider or all providers.",
+    inputSchema: z.object({
+      provider: z.enum(PROVIDER_CHOICES).optional().describe("Optional provider filter"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ provider }) => {
+    const providers = provider ? [provider] as const : PROVIDER_CHOICES
+    const results = await Promise.all(providers.map(async (providerId) => {
+      const resolved = getProviderOrError(providerId)
+      if (!resolved.provider) {
+        return {
+          provider: providerId,
+          available: false,
+          authenticated: false,
+          error: resolved.error,
+          account: null,
+        }
+      }
+
+      try {
+        const auth = await resolved.provider.checkAuth()
+        return {
+          provider: providerId,
+          available: true,
+          authenticated: auth.authenticated,
+          error: auth.authenticated ? null : auth.error,
+          account: auth.authenticated ? auth.account : null,
+        }
+      } catch (err) {
+        return {
+          provider: providerId,
+          available: false,
+          authenticated: false,
+          error: err instanceof Error ? err.message : String(err),
+          account: null,
+        }
+      }
+    }))
+
+    return jsonText(provider ? results[0] : results)
+  },
+)
 
 // ---------------------------------------------------------------------------
 // Tool: list_programs
@@ -440,6 +629,170 @@ const ConfigSchema = z.object({
 })
 
 server.registerTool(
+  "start_setup_session",
+  {
+    title: "Start Setup Session",
+    description:
+      "Start a conversational setup agent session. Use mode='analyze' for ideation or mode='direct' when you already know the target.",
+    inputSchema: z.object({
+      mode: z.enum(["direct", "analyze"]).describe("Conversation mode"),
+      message: z.string().optional().describe("Optional first message for direct mode"),
+      focus: z.string().optional().describe("Optional area to focus on for analyze mode"),
+      provider: z.enum(["claude", "codex", "opencode"]).optional().describe("Support-model provider override"),
+      model: z.string().optional().describe("Support-model name override"),
+      effort: z.enum(["low", "medium", "high", "max"]).optional().describe("Support-model effort override"),
+    }),
+  },
+  async ({ mode, message, focus, provider, model, effort }) => {
+    try {
+      const result = await startSetupSession(cwd, { mode, message, focus, provider, model, effort })
+      return jsonText({
+        session_id: result.session.id,
+        kind: result.session.kind,
+        provider: result.session.provider,
+        model: result.session.model,
+        effort: result.session.effort,
+        auto_sent: Boolean(result.firstTurn),
+        assistant_message: result.firstTurn?.assistantMessage ?? null,
+        tool_events: result.firstTurn?.toolEvents ?? [],
+        messages: result.firstTurn?.messages ?? result.session.messages,
+      })
+    } catch (err) {
+      return errorResult(`Failed to start setup session: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  },
+)
+
+server.registerTool(
+  "start_update_session",
+  {
+    title: "Start Update Session",
+    description:
+      "Start a conversational update agent session for an existing program. Auto-seeds the agent with the latest run context.",
+    inputSchema: z.object({
+      name: SlugSchema.describe("Program slug"),
+      provider: z.enum(["claude", "codex", "opencode"]).optional().describe("Support-model provider override"),
+      model: z.string().optional().describe("Support-model name override"),
+      effort: z.enum(["low", "medium", "high", "max"]).optional().describe("Support-model effort override"),
+    }),
+  },
+  async ({ name, provider, model, effort }) => {
+    try {
+      const result = await startUpdateSession(cwd, name, { provider, model, effort })
+      return jsonText({
+        session_id: result.session.id,
+        kind: result.session.kind,
+        program_slug: result.session.programSlug,
+        provider: result.session.provider,
+        model: result.session.model,
+        effort: result.session.effort,
+        assistant_message: result.firstTurn.assistantMessage,
+        tool_events: result.firstTurn.toolEvents,
+        messages: result.firstTurn.messages,
+      })
+    } catch (err) {
+      return errorResult(`Failed to start update session: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  },
+)
+
+server.registerTool(
+  "send_session_message",
+  {
+    title: "Send Session Message",
+    description:
+      "Send a user message to a setup/update session and wait for the agent's next reply.",
+    inputSchema: z.object({
+      session_id: z.string().min(1).describe("Session ID from start_setup_session or start_update_session"),
+      message: z.string().min(1).describe("User message to send"),
+    }),
+  },
+  async ({ session_id, message }) => {
+    try {
+      const result = await sendSessionMessage(cwd, session_id, message)
+      return jsonText({
+        session_id,
+        assistant_message: result.assistantMessage,
+        tool_events: result.toolEvents,
+        messages: result.messages,
+      })
+    } catch (err) {
+      return errorResult(`Failed to send session message: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  },
+)
+
+server.registerTool(
+  "get_session",
+  {
+    title: "Get Session",
+    description: "Get the current transcript and metadata for a setup/update session.",
+    inputSchema: z.object({
+      session_id: z.string().min(1).describe("Session ID"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ session_id }) => {
+    const session = await loadAgentSession(cwd, session_id)
+    if (!session) return errorResult(`Session "${session_id}" not found.`)
+    return jsonText({
+      session_id: session.id,
+      kind: session.kind,
+      program_slug: session.programSlug,
+      created_at: session.createdAt,
+      updated_at: session.updatedAt,
+      provider: session.provider,
+      model: session.model,
+      effort: session.effort,
+      messages: session.messages,
+    })
+  },
+)
+
+server.registerTool(
+  "list_sessions",
+  {
+    title: "List Sessions",
+    description: "List persisted setup/update conversation sessions.",
+    inputSchema: z.object({}),
+    annotations: { readOnlyHint: true },
+  },
+  async () => {
+    const sessions = await listAgentSessions(cwd)
+    return jsonText(sessions.map((session) => ({
+      session_id: session.id,
+      kind: session.kind,
+      program_slug: session.programSlug,
+      updated_at: session.updatedAt,
+      provider: session.provider,
+      model: session.model,
+      effort: session.effort,
+      message_count: session.messages.length,
+    })))
+  },
+)
+
+server.registerTool(
+  "delete_session",
+  {
+    title: "Delete Session",
+    description: "Delete a persisted setup/update conversation session.",
+    inputSchema: z.object({
+      session_id: z.string().min(1).describe("Session ID"),
+      confirm: z.literal(true).describe("Must be true to confirm deletion"),
+    }),
+    annotations: { destructiveHint: true },
+  },
+  async ({ session_id, confirm }) => {
+    if (!confirm) return errorResult("Deletion requires confirm=true.")
+    const session = await loadAgentSession(cwd, session_id)
+    if (!session) return errorResult(`Session "${session_id}" not found.`)
+    await deleteAgentSession(cwd, session_id)
+    return text(`Session '${session_id}' deleted.`)
+  },
+)
+
+server.registerTool(
   "create_program",
   {
     title: "Create Program",
@@ -634,8 +987,9 @@ server.registerTool(
     }
 
     try {
+      const validator = getSelfCommand("__validate_measurement")
       const proc = Bun.spawn(
-        ["bun", "run", VALIDATE_SCRIPT, measureSh, configJson, String(runs)],
+        [validator.command, ...validator.args, measureSh, configJson, String(runs)],
         {
           cwd: root,
           stdout: "pipe",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -369,10 +369,10 @@ server.registerTool(
   },
   async () => {
     const root = await getProjectRoot(cwd)
-    const programs = await listPrograms(cwd)
+    const programs = await listPrograms(root)
     if (programs.length === 0) return text("No programs found.")
 
-    const summaries = await loadProgramSummaries(cwd)
+    const summaries = await loadProgramSummaries(root)
     const summaryMap = new Map(summaries.map((s) => [s.slug, s.goal]))
 
     const result = await Promise.all(
@@ -849,7 +849,7 @@ server.registerTool(
     }
 
     // Ensure .autoauto directory and .gitignore
-    await ensureAutoAutoDir(cwd)
+    await ensureAutoAutoDir(root)
 
     // Create program directory
     await mkdir(programDir, { recursive: true })

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -553,7 +553,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
     try {
       const worktreePath = runState.in_place ? undefined : runState.worktree_path
       const effectiveCwd = worktreePath ?? cwd
-      const context = await buildFinalizeContext(effectiveCwd, runDir, runState, programConfig)
+      const context = await buildFinalizeContext(effectiveCwd, runDir, runState, programConfig, cwd)
       const systemPrompt = getFinalizeSystemPrompt(context)
       const initialMessage = await buildFinalizeInitialMessage(context)
       setFinalizeSystemPrompt(systemPrompt)

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -552,10 +552,16 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
 
     try {
       const worktreePath = runState.in_place ? undefined : runState.worktree_path
-      const effectiveCwd = worktreePath ?? cwd
-      const context = await buildFinalizeContext(effectiveCwd, runDir, runState, programConfig, cwd)
+      // Worktree may have been removed already (e.g. queue-sourced runs clean up
+      // immediately). Fall back to main checkout and use the branch name as ref.
+      const worktreeExists = worktreePath
+        ? await Bun.file(`${worktreePath}/.git`).exists()
+        : false
+      const effectiveCwd = worktreeExists ? worktreePath! : cwd
+      const headRef = worktreeExists ? "HEAD" : runState.branch_name
+      const context = await buildFinalizeContext(effectiveCwd, runDir, runState, programConfig, cwd, headRef)
       const systemPrompt = getFinalizeSystemPrompt(context)
-      const initialMessage = await buildFinalizeInitialMessage(context)
+      const initialMessage = await buildFinalizeInitialMessage(context, headRef)
       setFinalizeSystemPrompt(systemPrompt)
       setFinalizeInitialMessage(initialMessage)
       setFinalizeCwd(effectiveCwd)

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -370,7 +370,15 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
             setAgentStreamText(reconstructed.streamText)
             setIdeasText(reconstructed.ideasText)
             setSummaryText(reconstructed.summaryText)
-            setPhase("running")
+            if (reconstructed.state.phase === "crashed") {
+              setLastError(reconstructed.state.error ?? "Daemon crashed")
+              setPhase("error")
+            } else if (reconstructed.state.phase === "complete") {
+              setTerminationReason(reconstructed.state.termination_reason ?? null)
+              setPhase("complete")
+            } else {
+              setPhase("running")
+            }
             // Sync maxExpText from run-config for settings panel
             const currentMax = await getMaxExperiments(activeRunDir)
             if (!cancelled && currentMax != null) {

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -468,6 +468,17 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
                   } else if (final.state.phase === "complete") {
                     setPhase("complete")
                   } else {
+                    // Persist crashed state to disk so the run doesn't stay
+                    // stuck in a non-terminal phase after the TUI closes
+                    const crashedState: RunState = {
+                      ...final.state,
+                      phase: "crashed",
+                      error: logTail || "Daemon died unexpectedly",
+                      error_phase: final.state.phase,
+                      updated_at: new Date().toISOString(),
+                    }
+                    writeState(activeRunDir, crashedState).catch(() => {})
+                    setRunState(crashedState)
                     const detail = logTail ? `\n\n${logTail}` : ""
                     setLastError(`Daemon died unexpectedly while ${final.state.phase}${detail}`)
                     setPhase("error")

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -13,7 +13,7 @@ import { RunsTable } from "../components/RunsTable.tsx"
 import { formatShellError } from "../lib/git.ts"
 import { listDrafts, deleteDraft, type DraftSession, type DraftEntry } from "../lib/drafts.ts"
 import { readQueue, removeFromQueue, clearQueue, type QueueFile } from "../lib/queue.ts"
-import { abortAndDeleteActiveRuns } from "../lib/daemon-status.ts"
+import { abortAndDeleteActiveRuns, cleanupStaleRuns } from "../lib/daemon-status.ts"
 import { colors } from "../lib/theme.ts"
 
 interface HomeScreenProps {
@@ -63,6 +63,9 @@ async function loadHomeData(cwd: string): Promise<HomeData> {
         listRuns(programDir),
         loadProgramConfig(programDir).catch(() => null),
       ])
+
+      // Clean up runs whose daemon died while the TUI wasn't watching
+      await cleanupStaleRuns(programDir, runs)
 
       allRuns.push(...runs)
       if (config) programConfigs[p.name] = config

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -248,7 +248,7 @@ export function HomeScreen({ cwd, navigate, onSelectProgram, onSelectRun, onUpda
       }
       return
     }
-    if (key.name === "s") {
+    if (key.name === "s" && !(focusedPanel === "queue" && hasQueueItems && onResumeQueueRef.current)) {
       navigate("settings")
       return
     }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -131,7 +131,6 @@ export function HomeScreen({ cwd, navigate, onSelectProgram, onSelectRun, onUpda
     loadHomeData(cwd)
       .then((d) => {
         setData(d)
-        onResumeQueueRef.current?.()
       })
       .catch((err: unknown) => {
         setError(formatShellError(err))
@@ -337,6 +336,8 @@ export function HomeScreen({ cwd, navigate, onSelectProgram, onSelectRun, onUpda
         }
       } else if (key.name === "c") {
         setConfirmClearQueue(true)
+      } else if (key.name === "s") {
+        onResumeQueueRef.current?.()
       }
     }
   })

--- a/src/screens/PreRunScreen.tsx
+++ b/src/screens/PreRunScreen.tsx
@@ -282,7 +282,7 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
 
       <box height={1} />
 
-      <CycleField label="Run Mode" value={useWorktree ? "Worktree (recommended)" : "In-place"} isFocused={selected === 5} />
+      <CycleField label="Run Mode" value={useWorktree ? "Worktree" : "In-place"} hint={useWorktree ? "(recommended)" : undefined} description={useWorktree ? "Your checkout stays usable while experiments run in an isolated copy" : undefined} isFocused={selected === 5} />
       {!useWorktree && (
         <box flexDirection="column">
           <text fg={colors.error}>{"  \u26A0 DANGER: Runs git reset --hard in your main checkout."}</text>
@@ -291,10 +291,10 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
         </box>
       )}
 
-      <CycleField label="Keep Simplifications" value={keepSimplifications ? "On (recommended)" : "Off"} description={keepSimplifications ? "Auto-keep experiments that reduce code without regressing the metric" : "Only keep experiments that improve the metric"} isFocused={selected === 6} />
+      <CycleField label="Keep Simplifications" value={keepSimplifications ? "On" : "Off"} hint={keepSimplifications ? "(recommended)" : undefined} description={keepSimplifications ? "Free wins: keeps code-reducing changes even if the metric stays flat" : "Strict mode: only keep changes that measurably improve the metric"} isFocused={selected === 6} />
 
       {hasPreviousRuns && (
-        <CycleField label="Previous Run Context" value={carryForward ? "On" : "Off"} description={carryForward ? "Feed previous run results and ideas into experiments" : "Start fresh without previous run context"} isFocused={selected === 7} />
+        <CycleField label="Previous Run Context" value={carryForward ? "On" : "Off"} description={carryForward ? "Avoids repeating failed approaches, but may bias toward previous patterns" : "Fresh perspective for breaking out of local optima, but may re-try failed approaches"} isFocused={selected === 7} />
       )}
 
       <box height={1} />

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -311,8 +311,8 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
         label="Fallback Model"
         value={fallbackEnabled ? "On" : "Off"}
         description={fallbackEnabled
-          ? "Auto-switch to fallback when primary model hits limits"
-          : "Run stops when primary model hits quota or persistent rate limits"}
+          ? "Keeps the run going with a backup model, but experiment quality may drop"
+          : "Run stops cleanly on quota/rate limits — resume later to maintain quality"}
         isFocused={selected === ROW_FALLBACK_TOGGLE}
       />
       {fallbackEnabled && (
@@ -344,8 +344,8 @@ export function SettingsScreen({ cwd, navigate, config, onConfigChange }: Settin
         label="Ideas Backlog"
         value={config.ideasBacklogEnabled ? "On" : "Off"}
         description={config.ideasBacklogEnabled
-          ? "Capture why experiments worked or failed and what to try next"
-          : "Use results.tsv-based experiment memory only"}
+          ? "Prevents repeating failed approaches, but uses extra context per experiment"
+          : "Saves context for the agent, but may waste cycles re-trying dead ends"}
         isFocused={selected === ROW_IDEAS}
       />
       <box height={1} />

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+import pkg from "../package.json" with { type: "json" }
+
+export const AUTOAUTO_VERSION = pkg.version


### PR DESCRIPTION
## Summary
- add conversational MCP setup/update sessions with persisted transcripts and follow-up messaging
- add MCP project config, model listing, and auth inspection tools
- make MCP self-spawn paths work in compiled binaries and tolerate optional provider availability

## Testing
- bun typecheck
- bun test src/e2e/mcp-server.e2e.test.ts src/e2e/mcp-daemon.e2e.test.ts
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent MCP conversation sessions, an internal self-invocation command for validation/daemon modes, direct version output, and contextual hints in pre-run UI.

* **Bug Fixes**
  * Improved worktree fallback for finalization, more accurate git-clean detection for ignorable changes, and correct handling of reconstructed run phases.

* **Tests**
  * Expanded end-to-end coverage and new MCP testing helpers.

* **Refactor**
  * Modularized MCP/daemon wiring and safer provider registration.

* **Documentation**
  * New MCP server docs, refined system prompts, and clearer effort descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->