### PR TITLE
feat(guidance): add human steering for mid-run experiment direction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ src/
     CycleField.tsx       # Reusable cycle-through field component
     ModelPicker.tsx      # Model selection UI with provider-specific lists
     RunSettingsOverlay.tsx # Inline max-experiments editor overlay
+    GuidanceOverlay.tsx  # Human guidance textarea overlay (g hotkey)
   screens/
     FirstSetupScreen.tsx # First-time setup (provider/model + auth check)
     HomeScreen.tsx       # Two-panel: programs list + runs table
@@ -134,6 +135,7 @@ src/
     validate-measurement.ts  # Standalone measurement validation script
     experiment.ts          # Experiment agent spawning, context packets, lock detection
     experiment-loop.ts     # Main experiment loop orchestrator
+    guidance.ts            # Human guidance: read/write guidance.md for mid-run steering
     ideas-backlog.ts       # Ideas backlog: append/read per-experiment notes (ideas.md)
     model-options.ts       # Model picker option loading from providers
     format.ts              # Table formatting utilities (padRight, truncate, column allocation)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Hit run and AutoAuto:
 
 Each experiment agent gets a **context packet** — not the full chat history, but a structured summary: current baseline, recent results, git log of kept changes, diffs from recently discarded attempts, and an ideas backlog of what's been tried. This prevents repeating failed approaches while keeping context small.
 
+You can **steer the loop mid-run** by pressing `g` to set human guidance. The next experiment agent receives your direction as high-priority context — useful when the agent is stuck, drifting, or you have a hunch about what to try next. Guidance persists across terminal detach/reattach and can be cleared at any time.
+
 The live TUI dashboard shows:
 
 - **Stats header** — experiment count, keeps/discards, baseline vs best with improvement %, cost, and a sparkline
@@ -178,6 +180,7 @@ After the loop completes (or you stop it), a Finalize Agent reviews the accumula
           state.json                  # Run state checkpoint
           results.tsv                 # Append-only experiment outcomes
           ideas.md                    # Ideas backlog (optional)
+          guidance.md                 # Human steering (written by TUI/MCP)
           stream-001.log              # Per-experiment agent output
           ...
   worktrees/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ All agents use `permissionMode: "bypassPermissions"` and tools: Read, Write, Edi
 
 `src/lib/experiment.ts` — per-iteration agent sessions:
 
-- `buildContextPacket()` / `buildExperimentPrompt()` — assembles one-shot context
+- `buildContextPacket()` / `buildExperimentPrompt()` — assembles one-shot context (includes human guidance from `guidance.md` when present)
 - `runExperimentAgent()` — one-shot agent with streaming callbacks
 - `checkLockViolation()` — detects modifications to `.autoauto/` files
 
@@ -107,6 +107,7 @@ TUI fallback: on home screen mount, if queue has entries, `startNextFromQueue()`
 | `results.tsv` | Daemon (append) | TUI | Experiment outcomes |
 | `stream-NNN.log` | Daemon (append) | TUI | Agent streaming text |
 | `control.json` | TUI | Daemon (on SIGTERM) | Stop/abort commands |
+| `guidance.md` | TUI / MCP | Daemon (per iteration) | Human steering for experiment agent |
 | `queue.json` | TUI + Daemon | TUI + Daemon | Sequential run queue (atomic temp+rename) |
 | `queue.lock` | popQueue() | popQueue() | O_EXCL mutex for concurrent pop prevention |
 
@@ -126,7 +127,7 @@ Three-panel layout in `ExecutionScreen.tsx`:
 
 Two modes: spawn (creates worktree + daemon) and attach (connects to existing daemon).
 
-Keyboard shortcuts are phase-appropriate: during a running experiment `q`/`Ctrl+C`/`s`/`i` are available; after completion the shortcuts switch to `f` (finalize), `i` (ideas), and `Escape` (back).
+Keyboard shortcuts are phase-appropriate: during a running experiment `q`/`Ctrl+C`/`s`/`g`/`i` are available; after completion the shortcuts switch to `f` (finalize), `i` (ideas), and `Escape` (back).
 
 Stop/abort escalation: `q` -> confirmation -> stop-after-current; `Ctrl+C` -> abort; second `Ctrl+C` after 5s -> SIGKILL.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -97,6 +97,7 @@ Each experiment agent starts fresh. Instead of chat history, it gets a structure
 - Recent experiment results (status, metric, description)
 - Diffs from recently discarded experiments (so it doesn't retry failed ideas)
 - Git log of kept changes
+- Human guidance (if set — takes priority over ideas backlog)
 - The ideas backlog
 - Previous run context (if carry-forward is enabled)
 
@@ -112,6 +113,16 @@ An optional `ideas.md` file that accumulates notes across experiments:
 - What to avoid
 
 This is the agent's institutional memory. Without it, agents waste cycles retrying discarded approaches — one real-world case saw a test fix go through four different approaches before finding one that held, and the backlog prevented retrying the three that failed.
+
+## Human guidance
+
+While the experiment loop is fully autonomous, you can **steer it mid-run** by providing human guidance. Press `g` in the TUI (or use the `set_guidance` MCP tool) to write a direction for the experiment agent.
+
+Guidance is stored as `guidance.md` in the run directory. The daemon reads it at the start of each experiment iteration and injects it into the context packet as a high-priority `## Human Guidance` section — above the ideas backlog. The agent treats it as steering direction that takes precedence over its own ideas.
+
+This is most useful at **performance plateaus** (multiple consecutive discards), when the agent is **drifting** into unproductive directions, or when you have domain knowledge about what to try next. Inspired by the [guidance.md pattern](https://github.com/karpathy/autoresearch/issues/239) from the autoresearch community.
+
+Guidance is non-blocking — it takes effect on the next experiment without pausing the current one. It persists across TUI detach/reattach and can be cleared at any time.
 
 ## Carry forward (cross-run memory)
 
@@ -207,6 +218,7 @@ All AutoAuto state lives in `.autoauto/` inside your project, which is automatic
           state.json              # Run checkpoint
           results.tsv             # Experiment outcomes (append-only)
           ideas.md                # Ideas backlog
+          guidance.md             # Human steering (written by TUI/MCP)
           stream-001.log          # Per-experiment agent output
           summary.md              # Final report (after finalize)
 ```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,6 +21,7 @@ Quick reference for the core AutoAuto terms.
 | **Repeats** | Number of measurement runs per experiment. AutoAuto compares medians. |
 | **CV%** | Coefficient of variation. Setup-time stability grade for a measurement. |
 | **Context packet** | One-shot experiment input: baseline, recent results, discarded diffs, git history, backlog notes. |
+| **Human guidance** | User-written `guidance.md` in the run directory. Injected into the experiment agent's context as high-priority steering. Set via `g` in the TUI or `set_guidance` MCP tool. |
 | **Ideas backlog** | Optional `ideas.md` file with what was tried, why it worked or failed, and what to try next. |
 | **Carry forward** | Cross-run memory: previous run results and ideas fed into new experiments. Enabled by default; disable with `--no-carry-forward`. |
 | **Previous run context** | Kept experiment summaries + ideas backlog from earlier completed runs of the same program. |

--- a/src/components/GuidanceOverlay.tsx
+++ b/src/components/GuidanceOverlay.tsx
@@ -1,0 +1,67 @@
+import { useRef, useEffect, useCallback } from "react"
+import type { TextareaRenderable } from "@opentui/core"
+import { colors } from "../lib/theme.ts"
+
+interface GuidanceOverlayProps {
+  currentGuidance: string
+  onSave: (text: string) => void
+}
+
+export function GuidanceOverlay({ currentGuidance, onSave }: GuidanceOverlayProps) {
+  const textareaRef = useRef<TextareaRenderable | null>(null)
+
+  const handleSubmit = useCallback(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    onSave(textarea.plainText)
+  }, [onSave])
+
+  // Wire up onSubmit imperatively — React reconciler only maps these for <input>, not <textarea>
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    textarea.onSubmit = handleSubmit
+    if (currentGuidance) {
+      textarea.setText(currentGuidance)
+    }
+  }, [handleSubmit, currentGuidance])
+
+  return (
+    <box
+      position="absolute"
+      left={0}
+      top={0}
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+      zIndex={100}
+    >
+      <box
+        border
+        borderStyle="rounded"
+        title="Human Guidance"
+        flexDirection="column"
+        paddingX={1}
+        width={60}
+        backgroundColor={colors.surface}
+      >
+        <text fg={colors.textMuted}>
+          Steer the experiment agent. This will be included in the next experiment's context.
+        </text>
+        <box border borderStyle="rounded" height={8}>
+          <textarea
+            ref={textareaRef}
+            placeholder="e.g., Focus on optimizing the hot loop in parser.ts..."
+            focused
+            keyBindings={[
+              { name: "return", action: "submit" as const },
+              { name: "return", shift: true, action: "newline" as const },
+            ]}
+          />
+        </box>
+        <text fg={colors.textDim}>Enter: save · Shift+Enter: newline · Esc: cancel · Clear text + Enter: remove guidance</text>
+      </box>
+    </box>
+  )
+}

--- a/src/e2e/mcp-daemon.e2e.test.ts
+++ b/src/e2e/mcp-daemon.e2e.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock, type Mock } from "bun:test"
+import { join } from "node:path"
 import { createTestFixture, type TestFixture } from "./fixture.ts"
 import { createProgramForMcp, createRunForMcp, getTextContent, getJsonContent, type McpTestContext } from "./mcp-helpers.ts"
 
@@ -280,6 +281,81 @@ describe("MCP update_run_limit", () => {
     const result = await mcp.client.callTool({
       name: "update_run_limit",
       arguments: { name: "test-prog", max_experiments: 50 },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(getTextContent(result)).toContain("No active run")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// set_guidance
+// ---------------------------------------------------------------------------
+
+describe("MCP set_guidance", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpClient(fixture.cwd)
+    mockFindActiveRun.mockClear()
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("sets guidance on active run", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", { phase: "agent_running" })
+
+    mockFindActiveRun.mockImplementation(() =>
+      Promise.resolve({ runId: "20260412-100000", runDir, daemonAlive: true }),
+    )
+
+    const result = await mcp.client.callTool({
+      name: "set_guidance",
+      arguments: { name: "test-prog", text: "Focus on parser optimizations" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(getTextContent(result)).toContain("Guidance set")
+
+    // Verify file was written
+    const written = await Bun.file(join(runDir, "guidance.md")).text()
+    expect(written.trim()).toBe("Focus on parser optimizations")
+  })
+
+  test("clears guidance with empty text", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog", { phase: "agent_running" })
+
+    // Write some initial guidance
+    await Bun.write(join(runDir, "guidance.md"), "old guidance\n")
+
+    mockFindActiveRun.mockImplementation(() =>
+      Promise.resolve({ runId: "20260412-100000", runDir, daemonAlive: true }),
+    )
+
+    const result = await mcp.client.callTool({
+      name: "set_guidance",
+      arguments: { name: "test-prog", text: "" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(getTextContent(result)).toContain("Guidance cleared")
+    expect(await Bun.file(join(runDir, "guidance.md")).exists()).toBe(false)
+  })
+
+  test("returns error when no active run", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    mockFindActiveRun.mockImplementation(() => Promise.resolve(null))
+
+    const result = await mcp.client.callTool({
+      name: "set_guidance",
+      arguments: { name: "test-prog", text: "some guidance" },
     })
 
     expect(result.isError).toBe(true)

--- a/src/e2e/mcp-server.e2e.test.ts
+++ b/src/e2e/mcp-server.e2e.test.ts
@@ -767,3 +767,61 @@ describe("MCP validate_measurement", () => {
     expect(getTextContent(result)).toContain("not found")
   })
 }, 90_000)
+
+// ---------------------------------------------------------------------------
+// get_guidance
+// ---------------------------------------------------------------------------
+
+describe("MCP get_guidance", () => {
+  let fixture: TestFixture
+  let mcp: McpTestContext
+
+  beforeEach(async () => {
+    fixture = await createTestFixture()
+    mcp = await createMcpTestClient(fixture.cwd)
+  })
+
+  afterEach(async () => {
+    await mcp.cleanup()
+    await fixture.cleanup()
+  })
+
+  test("returns no guidance when file does not exist", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    await createRunForMcp(fixture.cwd, "test-prog")
+
+    const result = await mcp.client.callTool({
+      name: "get_guidance",
+      arguments: { name: "test-prog" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as { has_guidance: boolean; guidance: string | null }
+    expect(data.has_guidance).toBe(false)
+    expect(data.guidance).toBeNull()
+  })
+
+  test("returns guidance when file exists", async () => {
+    await createProgramForMcp(fixture.cwd, "test-prog")
+    const runDir = await createRunForMcp(fixture.cwd, "test-prog")
+    await Bun.write(join(runDir, "guidance.md"), "Focus on parser optimizations\n")
+
+    const result = await mcp.client.callTool({
+      name: "get_guidance",
+      arguments: { name: "test-prog" },
+    })
+
+    expect(result.isError).toBeFalsy()
+    const data = getJsonContent(result) as { has_guidance: boolean; guidance: string }
+    expect(data.has_guidance).toBe(true)
+    expect(data.guidance).toBe("Focus on parser optimizations")
+  })
+
+  test("returns error for non-existent program", async () => {
+    const result = await mcp.client.callTool({
+      name: "get_guidance",
+      arguments: { name: "no-such" },
+    })
+    expect(result.isError).toBe(true)
+  })
+})

--- a/src/lib/daemon-client.ts
+++ b/src/lib/daemon-client.ts
@@ -17,3 +17,4 @@ export {
   readDaemonLogTail,
   type DaemonStatus,
 } from "./daemon-status.ts"
+export { readGuidance, writeGuidance } from "./guidance.ts"

--- a/src/lib/daemon-status.ts
+++ b/src/lib/daemon-status.ts
@@ -6,6 +6,7 @@ import type { RunState, ExperimentResult, RunInfo } from "./run.ts"
 import { readAllResults, readState, getMetricHistory, backfillFinalizedAt, listRuns, isRunActive, writeState } from "./run.ts"
 import type { ProgramConfig } from "./programs.ts"
 import { loadProgramConfig, getProgramDir } from "./programs.ts"
+import { readGuidance } from "./guidance.ts"
 import {
   readDaemonJson,
   readRunConfig,
@@ -86,16 +87,18 @@ export async function reconstructState(runDir: string, programDir: string): Prom
   streamText: string
   ideasText: string
   summaryText: string
+  guidanceText: string
 }> {
   const [state, results, programConfig] = await Promise.all([
     readState(runDir),
     readAllResults(runDir),
     loadProgramConfig(programDir),
   ])
-  const [streamText, ideasText, summaryText] = await Promise.all([
+  const [streamText, ideasText, summaryText, guidanceText] = await Promise.all([
     readStreamTail(runDir, state.experiment_number),
     Bun.file(join(runDir, "ideas.md")).text().catch(() => ""),
     Bun.file(join(runDir, "summary.md")).text().catch(() => ""),
+    readGuidance(runDir),
   ])
 
   backfillFinalizedAt(state, Boolean(summaryText))
@@ -108,6 +111,7 @@ export async function reconstructState(runDir: string, programDir: string): Prom
     streamText,
     ideasText,
     summaryText,
+    guidanceText,
   }
 }
 

--- a/src/lib/daemon-watcher.ts
+++ b/src/lib/daemon-watcher.ts
@@ -1,6 +1,7 @@
 import { watch, statSync, readFileSync, type FSWatcher } from "node:fs"
 import { join } from "node:path"
 import { streamLogName } from "./daemon-callbacks.ts"
+import { readGuidance } from "./guidance.ts"
 import type { RunState, ExperimentResult } from "./run.ts"
 import type { QuotaInfo } from "./agent/types.ts"
 import { readAllResults, readState, getMetricHistory } from "./run.ts"
@@ -13,6 +14,7 @@ export interface WatchCallbacks {
   onStreamReset?: () => void
   onToolStatus?: (status: string | null) => void
   onIdeasChange?: (text: string) => void
+  onGuidanceChange?: (text: string) => void
   onQuotaChange?: (quota: QuotaInfo) => void
   onDaemonDied: () => void
 }
@@ -80,6 +82,8 @@ export function watchRunDir(
         } else if (file === "ideas.md" && callbacks.onIdeasChange) {
           const text = await Bun.file(join(runDir, "ideas.md")).text()
           callbacks.onIdeasChange(text)
+        } else if (file === "guidance.md" && callbacks.onGuidanceChange) {
+          callbacks.onGuidanceChange(await readGuidance(runDir))
         } else if (file === "quota.json" && callbacks.onQuotaChange) {
           const data = await Bun.file(join(runDir, "quota.json")).json() as QuotaInfo
           callbacks.onQuotaChange(data)
@@ -205,6 +209,7 @@ export function watchRunDir(
       scheduleRead("results.tsv")
       if (currentStreamFile) scheduleRead(currentStreamFile)
       if (callbacks.onQuotaChange) scheduleRead("quota.json")
+      if (callbacks.onGuidanceChange) scheduleRead("guidance.md")
     }, 300)
   }
 

--- a/src/lib/experiment.ts
+++ b/src/lib/experiment.ts
@@ -20,6 +20,7 @@ import {
   readIdeasBacklogSummary,
   type ExperimentNotes,
 } from "./ideas-backlog.ts"
+import { readGuidance } from "./guidance.ts"
 
 // --- Types ---
 
@@ -40,6 +41,7 @@ export interface ContextPacket {
   last_outcome: string
   discarded_diffs: string
   ideas_backlog: string
+  human_guidance?: string
   secondary_metrics?: Record<string, { direction: "lower" | "higher"; last_kept_value?: number }>
   consecutive_discards: number
   max_consecutive_discards: number
@@ -76,10 +78,11 @@ export async function buildContextPacket(
   config: { metric_field: string; direction: "lower" | "higher"; secondary_metrics?: Record<string, { direction: "lower" | "higher" }> },
   options: { ideasBacklogEnabled?: boolean; consecutiveDiscards?: number; maxConsecutiveDiscards?: number; maxTurns?: number; measurementDiagnostics?: string; previousRunContext?: PreviousRunContext } = {},
 ): Promise<ContextPacket> {
-  const [programMd, resultsRaw, recentGitLog] = await Promise.all([
+  const [programMd, resultsRaw, recentGitLog, humanGuidance] = await Promise.all([
     Bun.file(join(programDir, "program.md")).text(),
     Bun.file(join(runDir, "results.tsv")).text(),
     getRecentLog(cwd, 15),
+    readGuidance(runDir),
   ])
   const ideasBacklog = options.ideasBacklogEnabled === false
     ? ""
@@ -154,6 +157,7 @@ export async function buildContextPacket(
     last_outcome: lastOutcome,
     discarded_diffs: discardedDiffs,
     ideas_backlog: ideasBacklog,
+    human_guidance: humanGuidance || undefined,
     secondary_metrics: secondaryMetrics,
     consecutive_discards: options.consecutiveDiscards ?? 0,
     max_consecutive_discards: options.maxConsecutiveDiscards ?? 10,
@@ -272,6 +276,11 @@ Detailed diagnostic output from the last measurement run. Use this to identify e
 ${packet.measurement_diagnostics}
 \`\`\`
 ` : ""}
+${packet.human_guidance ? `
+## Human Guidance
+The human operator has provided the following direction. Treat this as high-priority steering — it takes precedence over the ideas backlog.
+${packet.human_guidance}
+` : ""}
 ${packet.ideas_backlog ? `
 ## Ideas Backlog
 ${packet.ideas_backlog}
@@ -279,7 +288,7 @@ ${packet.ideas_backlog}
 
 ${getExplorationDirective(packet.consecutive_discards, packet.max_consecutive_discards)}
 
-Review the recent results and discarded experiments${packet.ideas_backlog ? ", ideas backlog" : ""}${packet.previous_results || packet.previous_ideas ? ", and previous run history" : ""} above. Focus on what was tried, why it failed, and what should be tried next.
+Review the recent results and discarded experiments${packet.human_guidance ? ", human guidance" : ""}${packet.ideas_backlog ? ", ideas backlog" : ""}${packet.previous_results || packet.previous_ideas ? ", and previous run history" : ""} above. Focus on what was tried, why it failed, and what should be tried next.
 Implement ONE change, validate, and commit. Then stop.`
 }
 

--- a/src/lib/guidance.test.ts
+++ b/src/lib/guidance.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { readGuidance, writeGuidance } from "./guidance.ts"
+
+describe("guidance", () => {
+  test("returns empty string for missing file", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      expect(await readGuidance(runDir)).toBe("")
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+
+  test("write and read roundtrip", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      await writeGuidance(runDir, "Focus on parser optimizations")
+      const result = await readGuidance(runDir)
+      expect(result).toBe("Focus on parser optimizations")
+
+      // File on disk should have trailing newline
+      const raw = await readFile(join(runDir, "guidance.md"), "utf-8")
+      expect(raw).toBe("Focus on parser optimizations\n")
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+
+  test("trims whitespace on write and read", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      await writeGuidance(runDir, "  padded text  \n\n")
+      expect(await readGuidance(runDir)).toBe("padded text")
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+
+  test("clearing guidance deletes the file", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      await writeGuidance(runDir, "some guidance")
+      expect(await readGuidance(runDir)).toBe("some guidance")
+
+      await writeGuidance(runDir, "")
+      expect(await readGuidance(runDir)).toBe("")
+      expect(await Bun.file(join(runDir, "guidance.md")).exists()).toBe(false)
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+
+  test("clearing whitespace-only guidance deletes the file", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      await writeGuidance(runDir, "some guidance")
+      await writeGuidance(runDir, "   \n  ")
+      expect(await readGuidance(runDir)).toBe("")
+      expect(await Bun.file(join(runDir, "guidance.md")).exists()).toBe(false)
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+
+  test("clearing non-existent file does not throw", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      await writeGuidance(runDir, "")
+      // Should not throw
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+
+  test("truncates long guidance", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      const longText = "x".repeat(3000)
+      await writeGuidance(runDir, longText)
+      const result = await readGuidance(runDir)
+      expect(result.length).toBeLessThan(3000)
+      expect(result).toEndWith("[truncated]")
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+
+  test("replaces existing guidance atomically", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      await writeGuidance(runDir, "first guidance")
+      await writeGuidance(runDir, "second guidance")
+      expect(await readGuidance(runDir)).toBe("second guidance")
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+
+  test("preserves multi-line guidance", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "autoauto-guidance-"))
+    try {
+      const multiline = "Line 1\nLine 2\nLine 3"
+      await writeGuidance(runDir, multiline)
+      expect(await readGuidance(runDir)).toBe(multiline)
+    } finally {
+      await rm(runDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/lib/guidance.test.ts
+++ b/src/lib/guidance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdtemp, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { readGuidance, writeGuidance } from "./guidance.ts"
@@ -22,7 +22,7 @@ describe("guidance", () => {
       expect(result).toBe("Focus on parser optimizations")
 
       // File on disk should have trailing newline
-      const raw = await readFile(join(runDir, "guidance.md"), "utf-8")
+      const raw = await Bun.file(join(runDir, "guidance.md")).text()
       expect(raw).toBe("Focus on parser optimizations\n")
     } finally {
       await rm(runDir, { recursive: true, force: true })

--- a/src/lib/guidance.ts
+++ b/src/lib/guidance.ts
@@ -1,0 +1,33 @@
+import { join } from "node:path"
+import { rename, unlink } from "node:fs/promises"
+
+const GUIDANCE_FILE = "guidance.md"
+const MAX_GUIDANCE_LENGTH = 2000
+
+export async function readGuidance(runDir: string, maxChars = MAX_GUIDANCE_LENGTH): Promise<string> {
+  try {
+    const raw = await Bun.file(join(runDir, GUIDANCE_FILE)).text()
+    const trimmed = raw.trim()
+    if (!trimmed) return ""
+    if (trimmed.length > maxChars) return trimmed.slice(0, maxChars) + "\n[truncated]"
+    return trimmed
+  } catch {
+    return ""
+  }
+}
+
+export async function writeGuidance(runDir: string, text: string): Promise<void> {
+  const trimmed = text.trim()
+  const guidancePath = join(runDir, GUIDANCE_FILE)
+  if (!trimmed) {
+    try {
+      await unlink(guidancePath)
+    } catch {
+      // File may not exist
+    }
+    return
+  }
+  const tmpPath = guidancePath + ".tmp"
+  await Bun.write(tmpPath, trimmed + "\n")
+  await rename(tmpPath, guidancePath)
+}

--- a/src/lib/guidance.ts
+++ b/src/lib/guidance.ts
@@ -22,12 +22,12 @@ export async function writeGuidance(runDir: string, text: string): Promise<void>
   if (!trimmed) {
     try {
       await unlink(guidancePath)
-    } catch {
-      // File may not exist
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
     }
     return
   }
-  const tmpPath = guidancePath + ".tmp"
+  const tmpPath = `${guidancePath}.${process.pid}.${Date.now()}.tmp`
   await Bun.write(tmpPath, trimmed + "\n")
   await rename(tmpPath, guidancePath)
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -71,6 +71,7 @@ const VALIDATE_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "lib", "va
 
 /** Reusable slug schema — prevents path traversal via names like "../../etc" */
 const SlugSchema = z.string().min(1).regex(/^[a-z0-9-]+$/, "Must be lowercase letters, numbers, and hyphens only")
+const RunIdSchema = z.string().regex(/^[A-Za-z0-9._-]+$/, "Invalid run_id format")
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -758,7 +759,7 @@ server.registerTool(
       "Get the status of the latest (or a specific) run: phase, metrics, progress, cost, and whether the daemon is alive.",
     inputSchema: z.object({
       name: SlugSchema.describe("Program slug"),
-      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+      run_id: RunIdSchema.optional().describe("Specific run ID (default: latest)"),
     }),
     annotations: { readOnlyHint: true },
   },
@@ -873,7 +874,7 @@ server.registerTool(
       "Get the experiment results table for a run: experiment number, status (keep/discard/crash), metric value, change %, commit, and description.",
     inputSchema: z.object({
       name: SlugSchema.describe("Program slug"),
-      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+      run_id: RunIdSchema.optional().describe("Specific run ID (default: latest)"),
       limit: z.number().int().min(1).optional().describe("Return only the last N results"),
     }),
     annotations: { readOnlyHint: true },
@@ -946,7 +947,7 @@ server.registerTool(
         z.number().int().min(0),
         z.literal("latest"),
       ]).describe("Experiment number (0 = baseline) or 'latest'"),
-      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+      run_id: RunIdSchema.optional().describe("Specific run ID (default: latest)"),
     }),
     annotations: { readOnlyHint: true },
   },
@@ -1123,7 +1124,7 @@ server.registerTool(
       "Get the current human steering guidance for an active or completed run.",
     inputSchema: z.object({
       name: SlugSchema.describe("Program slug"),
-      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+      run_id: RunIdSchema.optional().describe("Specific run ID (default: latest)"),
     }),
     annotations: { readOnlyHint: true },
   },
@@ -1169,7 +1170,7 @@ server.registerTool(
     ].join(" "),
     inputSchema: z.object({
       name: SlugSchema.describe("Program slug"),
-      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+      run_id: RunIdSchema.optional().describe("Specific run ID (default: latest)"),
       generate: z.boolean().default(false).describe("Generate stats summary if none exists (only for completed/crashed runs)"),
     }),
     annotations: { readOnlyHint: false },

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,6 +46,8 @@ import {
   forceKillDaemon,
   findActiveRun,
   updateMaxExperiments,
+  readGuidance,
+  writeGuidance,
 } from "./lib/daemon-client.ts"
 import {
   loadProjectConfig,
@@ -141,7 +143,7 @@ export function createMcpServer(cwd: string): McpServer {
         "AutoAuto manages autoresearch programs — autonomous experiment loops that optimize a single metric on any codebase.",
         "Setup workflow: (1) get_setup_guide to learn artifact formats, (2) list_programs to check for duplicates, (3) create_program to write all files, (4) validate_measurement to verify stability.",
         "Run workflow: (1) start_run to launch an experiment loop, (2) get_run_status to check progress, (3) get_run_results to see experiment outcomes, (4) get_experiment_log for agent output on a specific experiment, (5) stop_run to stop when satisfied, (6) get_run_summary for a post-run report.",
-        "Management: list_programs for overview, get_program to inspect, update_program to modify, delete_program to remove. Use list_runs to see run history, update_run_limit to change max experiments mid-run.",
+        "Management: list_programs for overview, get_program to inspect, update_program to modify, delete_program to remove. Use list_runs to see run history, update_run_limit to change max experiments mid-run, set_guidance to steer the agent's direction.",
       ].join("\n"),
     },
   )
@@ -1073,6 +1075,82 @@ server.registerTool(
     await updateMaxExperiments(active.runDir, max_experiments)
 
     return jsonText({ run_id: active.runId, max_experiments })
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: set_guidance
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "set_guidance",
+  {
+    title: "Set Guidance",
+    description:
+      "Set human steering guidance for an active run. The experiment agent reads this at the start of each iteration and treats it as high-priority direction. Pass empty text to clear guidance.",
+    inputSchema: z.object({
+      name: SlugSchema.describe("Program slug"),
+      text: z.string().max(2000).describe("Guidance text for the experiment agent (empty string to clear, max 2000 chars)"),
+    }),
+  },
+  async ({ name, text: guidanceText }) => {
+    const root = await getProjectRoot(cwd)
+    const programDir = getProgramDir(root, name)
+
+    const active = await findActiveRun(programDir)
+    if (!active) return errorResult(`No active run for '${name}'.`)
+    if (!active.daemonAlive) return errorResult("Daemon is not running. Run may have already completed.")
+
+    await writeGuidance(active.runDir, guidanceText)
+
+    const trimmed = guidanceText.trim()
+    if (!trimmed) {
+      return text(`Guidance cleared for '${name}'. The next experiment will not receive human guidance.`)
+    }
+    return text(`Guidance set for '${name}'. The next experiment will include this in its context.`)
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Tool: get_guidance
+// ---------------------------------------------------------------------------
+
+server.registerTool(
+  "get_guidance",
+  {
+    title: "Get Guidance",
+    description:
+      "Get the current human steering guidance for an active or completed run.",
+    inputSchema: z.object({
+      name: SlugSchema.describe("Program slug"),
+      run_id: z.string().optional().describe("Specific run ID (default: latest)"),
+    }),
+    annotations: { readOnlyHint: true },
+  },
+  async ({ name, run_id }) => {
+    let resolved: Awaited<ReturnType<typeof resolveProgram>>
+    try {
+      resolved = await resolveProgram(name)
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+
+    let runDir: string
+    let resolvedRunId: string
+    try {
+      const r = await resolveRunDir(resolved.programDir, run_id)
+      runDir = r.runDir
+      resolvedRunId = r.runId
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err))
+    }
+
+    const guidance = await readGuidance(runDir)
+    return jsonText({
+      run_id: resolvedRunId,
+      has_guidance: guidance.length > 0,
+      guidance: guidance || null,
+    })
   },
 )
 

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -561,9 +561,15 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
   const handleGuidanceSave = useCallback((text: string) => {
     setShowGuidance(false)
     const trimmed = text.trim()
+    const prev = guidanceText
     setGuidanceText(trimmed)
-    if (runDir) writeGuidance(runDir, trimmed).catch(() => {})
-  }, [runDir])
+    if (runDir) {
+      writeGuidance(runDir, trimmed).catch((err) => {
+        setGuidanceText(prev)
+        setLastError(formatShellError(err, "Failed to save guidance"))
+      })
+    }
+  }, [runDir, guidanceText])
 
   const handleFinalize = useCallback(async () => {
     if (!runState || !runDir || !programConfig) return

--- a/src/screens/ExecutionScreen.tsx
+++ b/src/screens/ExecutionScreen.tsx
@@ -29,10 +29,12 @@ import {
   updateMaxExperiments,
   getMaxExperiments,
   readDaemonLogTail,
+  writeGuidance,
   type DaemonWatcher,
 } from "../lib/daemon-client.ts"
 import { RunCompletePrompt } from "../components/RunCompletePrompt.tsx"
 import { RunSettingsOverlay } from "../components/RunSettingsOverlay.tsx"
+import { GuidanceOverlay } from "../components/GuidanceOverlay.tsx"
 import { StatsHeader } from "../components/StatsHeader.tsx"
 import { ResultsTable } from "../components/ResultsTable.tsx"
 import { AgentPanel } from "../components/AgentPanel.tsx"
@@ -258,6 +260,8 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
   const [settingsError, setSettingsError] = useState<string | null>(null)
   const [quotaInfo, setQuotaInfo] = useState<QuotaInfo | undefined>()
   const [ideasText, setIdeasText] = useState("")
+  const [guidanceText, setGuidanceText] = useState("")
+  const [showGuidance, setShowGuidance] = useState(false)
   const [summaryText, setSummaryText] = useState("")
   const [showIdeas, setShowIdeas] = useState(true)
   const [activeBottomTab, setActiveBottomTab] = useState<"agent" | "ideas">("agent")
@@ -329,6 +333,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
                 setExperimentNumber(reconstructed.state.experiment_number)
                 setAgentStreamText(reconstructed.streamText)
                 setIdeasText(reconstructed.ideasText)
+                setGuidanceText(reconstructed.guidanceText)
                 setSummaryText(reconstructed.summaryText)
                 setTerminationReason(reconstructed.state.termination_reason ?? null)
                 if (currentMax != null) {
@@ -370,6 +375,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
             setExperimentNumber(reconstructed.state.experiment_number)
             setAgentStreamText(reconstructed.streamText)
             setIdeasText(reconstructed.ideasText)
+            setGuidanceText(reconstructed.guidanceText)
             setSummaryText(reconstructed.summaryText)
             if (reconstructed.state.phase === "crashed") {
               setLastError(reconstructed.state.error ?? "Daemon crashed")
@@ -454,6 +460,10 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
             onIdeasChange: (text) => {
               if (cancelled) return
               setIdeasText(text)
+            },
+            onGuidanceChange: (text) => {
+              if (cancelled) return
+              setGuidanceText(text)
             },
             onQuotaChange: (quota) => {
               if (cancelled) return
@@ -547,6 +557,13 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
   }, [])
 
   const handleDirtyQuit = useCallback(() => navigate("home"), [navigate])
+
+  const handleGuidanceSave = useCallback((text: string) => {
+    setShowGuidance(false)
+    const trimmed = text.trim()
+    setGuidanceText(trimmed)
+    if (runDir) writeGuidance(runDir, trimmed).catch(() => {})
+  }, [runDir])
 
   const handleFinalize = useCallback(async () => {
     if (!runState || !runDir || !programConfig) return
@@ -763,6 +780,14 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
       return
     }
 
+    // Guidance overlay — textarea handles input; only intercept Escape
+    if (showGuidance) {
+      if (key.name === "escape") {
+        setShowGuidance(false)
+      }
+      return
+    }
+
     // Stop confirmation dialog
     if (showStopConfirm) {
       if (key.name === "y") {
@@ -829,6 +854,11 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
 
       if (key.name === "s") {
         setShowSettings(true)
+        return
+      }
+
+      if (key.name === "g" && !readOnly) {
+        setShowGuidance(true)
         return
       }
 
@@ -977,6 +1007,13 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
             />
           )}
 
+          {showGuidance && (
+            <GuidanceOverlay
+              currentGuidance={guidanceText}
+              onSave={handleGuidanceSave}
+            />
+          )}
+
           {showStopConfirm && (
             <box paddingX={1}>
               <text fg={colors.warning} selectable>Stop after current experiment (y) / Abort immediately (a) / Cancel (n)</text>
@@ -996,7 +1033,7 @@ export function ExecutionScreen({ cwd, programSlug, modelConfig, supportModelCon
           )}
 
           <box paddingX={1} flexShrink={0}>
-            <text fg={colors.textMuted}>Esc: detach · Tab: switch panel · s: settings · q: stop{ideasVisible ? " · [/]: agent/ideas · i: ideas" : ideasText.length > 0 ? " · i: ideas" : ""}</text>
+            <text fg={colors.textMuted}>Esc: detach · Tab: switch panel · s: settings{readOnly ? "" : ` · g: guide${guidanceText ? " (active)" : ""}`} · q: stop{ideasVisible ? " · [/]: agent/ideas · i: ideas" : ideasText.length > 0 ? " · i: ideas" : ""}</text>
           </box>
         </box>
       )}


### PR DESCRIPTION
## Summary

- **TUI hotkey**: press `g` during execution to write steering guidance via a textarea overlay. Guidance persists across detach/reattach and can be cleared (empty + Enter).
- **Daemon integration**: reads `guidance.md` from the run directory at each experiment iteration boundary, injecting it into the context packet as a `## Human Guidance` section above the ideas backlog.
- **MCP tools**: `set_guidance` (write/clear guidance on active runs) and `get_guidance` (read guidance from any run).
- **File-based IPC**: atomic writes (temp+rename), `fs.watch` + polling fallback, consistent `readGuidance()` utility used everywhere.

Inspired by the [`guidance.md` pattern](https://github.com/karpathy/autoresearch/issues/239) from the autoresearch community — a file the human edits anytime, read by the agent each iteration. Most useful at performance plateaus, agent drift, or when the human has domain knowledge about what to try next.

### Files changed

| Area | Files |
|------|-------|
| Core | `guidance.ts` (new), `experiment.ts`, `daemon-watcher.ts`, `daemon-status.ts`, `daemon-client.ts` |
| TUI | `GuidanceOverlay.tsx` (new), `ExecutionScreen.tsx` |
| MCP | `mcp.ts` (`set_guidance`, `get_guidance`) |
| Tests | `guidance.test.ts` (9 unit), `mcp-server.e2e.test.ts` (+3), `mcp-daemon.e2e.test.ts` (+3) |
| Docs | `README.md`, `concepts.md`, `architecture.md`, `glossary.md`, `CLAUDE.md` |

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — 0 errors (128 pre-existing warnings unchanged)
- [x] `bun test src/lib/` — 204 unit tests pass
- [x] `bun test src/e2e/mcp-server.e2e.test.ts` — 32 tests pass (+3 new)
- [x] `bun test src/e2e/mcp-daemon.e2e.test.ts` — 12 tests pass (+3 new)
- [ ] Manual TUI test: start run → `g` → write guidance → verify `guidance.md` created → `g` again → verify pre-populated → clear + Enter → verify deleted
- [ ] Manual TUI test: detach → reattach → verify guidance state persists and footer shows `(active)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human guidance: press "g" during execution to open a guidance overlay, submit steering text for the next iteration; guidance persists across detach/reattach and is shown in the UI footer when active.
  * Added programmatic management tools to set/get guidance.

* **Documentation**
  * Updated docs and glossary to describe human guidance behavior, lifecycle, and controls.

* **Tests**
  * Added end-to-end and unit tests for guidance read/write and management tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->