### PR TITLE
feat(measure): add Mann-Whitney U statistical significance testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,8 @@ src/
     auth.ts              # Authentication checking via agent provider
     config.ts            # Project config CRUD (.autoauto/config.json)
     git.ts               # Git operations (branch, revert, log, SHA, diff stats)
-    measure.ts           # Measurement execution, validation, comparison
+    measure.ts           # Measurement execution, validation, comparison, significance testing
+    stats.ts             # Mann-Whitney U test (exact DP + normal approximation)
     programs.ts          # Filesystem ops, program CRUD, config types
     push-stream.ts       # Push-based async iterable utility
     queue.ts               # Sequential run queue: persistence, manipulation, daemon chaining

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,7 @@ Stop/abort escalation: `q` -> confirmation -> stop-after-current; `Ctrl+C` -> ab
 
 - `runMeasurement()` — single execution with JSON parsing and validation
 - `runMeasurementSeries()` — N repeated measurements with median aggregation
-- `compareMetric()` — relative change comparison against noise threshold
+- `compareMetricWithSignificance()` — relative change comparison against noise threshold with Mann-Whitney U p-value override
 - `checkQualityGates()` — threshold enforcement
 
 `src/lib/validate-measurement.ts` — standalone script for setup-time stability validation: runs measure.sh N times, computes CV%, recommends config.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -55,8 +55,8 @@ An **experiment** is a single iteration of the loop:
 2. The agent makes one change and commits
 3. AutoAuto measures the result (median of N runs of `measure.sh`)
 4. Decision:
-   - **Keep** — metric improved beyond the noise threshold and all quality gates passed
-   - **Discard** — metric regressed, was within noise, or a quality gate failed (reverted via `git reset --hard`)
+   - **Keep** — metric improved beyond the noise threshold (or statistically significant via Mann-Whitney U, p < 0.05) and all quality gates passed
+   - **Discard** — metric regressed, was within noise without statistical significance, or a quality gate failed (reverted via `git reset --hard`)
    - **Crash** — agent error, timeout, or invalid output
 
 Each experiment uses a fresh agent with no memory beyond the context packet. This prevents narrative momentum — where an agent becomes attached to a failing approach — and enables clean recovery from any failure.
@@ -77,7 +77,7 @@ The measurement system is the heart of AutoAuto. Your `measure.sh` script output
 
 **Metric field and direction.** One field is the primary metric to optimize. It has a direction: `"lower"` (e.g., latency) or `"higher"` (e.g., accuracy).
 
-**Noise threshold.** The minimum relative improvement (as a decimal fraction, e.g., 0.02 = 2%) to accept a change. Improvements below this are considered noise and discarded. AutoAuto helps you set this during setup by measuring your script's variance.
+**Noise threshold.** The minimum relative improvement (as a decimal fraction, e.g., 0.02 = 2%) to accept a change. Improvements below this are considered noise and discarded — unless the Mann-Whitney U test shows the difference is statistically significant (p < 0.05). AutoAuto helps you set this during setup by measuring your script's variance.
 
 **Repeats.** How many times `measure.sh` runs per experiment (typically 3-5). AutoAuto uses the median value for comparison, filtering out outliers.
 
@@ -85,7 +85,7 @@ The measurement system is the heart of AutoAuto. Your `measure.sh` script output
 
 **Simplicity criterion.** Experiments that are within noise but reduce lines of code are auto-kept. This rewards code simplification even without a metric gain. Note: simplification keeps do not reset the consecutive-discard counter — they don't count as real progress for stagnation detection. This behavior can be disabled by setting `"keep_simplifications": false` in `config.json` — useful for prompt/template optimization where LOC is meaningless, or when the measurement harness has known coverage gaps.
 
-**Statistical significance.** With 2+ repeats, AutoAuto runs a Mann-Whitney U test on the raw samples and shows a p-value alongside each result. The noise threshold still makes the keep/discard decision — the p-value is supplementary confidence info. More repeats = more statistical power (minimum p is 0.1 at 3 repeats, ~0.008 at 5).
+**Statistical significance.** With 2+ repeats, AutoAuto runs a Mann-Whitney U test (non-parametric, no normality assumption) on the raw samples and shows a p-value alongside each result. The p-value can override the noise threshold: if an improvement falls within the threshold but the Mann-Whitney test shows it's statistically significant (p < 0.05), the experiment is kept. This prevents discarding small-but-real improvements. More repeats = more statistical power (minimum p is 0.1 at 3 repeats, ~0.008 at 5). Use 5+ repeats if you want p < 0.05 significance to be achievable.
 
 **Re-baselining.** After every kept experiment, AutoAuto re-measures the baseline on the new code. It also re-measures after consecutive discards to detect environment drift.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,7 +15,7 @@ Quick reference for the core AutoAuto terms.
 | **Crash** | Failed experiment: agent error, timeout, invalid output, lock violation, or measurement failure. |
 | **Metric field** | Primary numeric output being optimized, e.g. `lcp_ms`. |
 | **Direction** | Whether the metric is `"lower"`-is-better or `"higher"`-is-better. |
-| **Noise threshold** | Minimum relative improvement required to count as real signal. Can be overridden by Mann-Whitney U statistical significance (p < 0.05). |
+| **Noise threshold** | Minimum relative improvement required to count as real signal, unless Mann-Whitney U shows statistical significance (p < 0.05). |
 | **p-value** | Two-sided Mann-Whitney U p-value comparing baseline vs experiment samples. Shown as `p≤` when at the minimum for the sample size. |
 | **Quality gate** | Secondary metric with a hard min/max threshold that must not be violated. |
 | **Secondary metric** | Informational tracked metric shown to the agent but not used as a hard gate. |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -10,12 +10,13 @@ Quick reference for the core AutoAuto terms.
 | **Experiment** | One loop iteration: fresh agent, one change, one commit, one keep/discard/crash decision. |
 | **Baseline** | Current metric value to beat. Re-measured after keeps and periodically after discards. |
 | **Original baseline** | Metric value at experiment 0. Used for overall improvement reporting. |
-| **Keep** | Accepted experiment: improved beyond noise threshold and passed all quality gates. |
+| **Keep** | Accepted experiment: improved beyond noise threshold (or statistically significant improvement via Mann-Whitney U, p < 0.05) and passed all quality gates. |
 | **Discard** | Rejected experiment: regressed, stayed within noise, or failed a quality gate. Reverted in the worktree with `git reset --hard`. |
 | **Crash** | Failed experiment: agent error, timeout, invalid output, lock violation, or measurement failure. |
 | **Metric field** | Primary numeric output being optimized, e.g. `lcp_ms`. |
 | **Direction** | Whether the metric is `"lower"`-is-better or `"higher"`-is-better. |
-| **Noise threshold** | Minimum relative improvement required to count as real signal. |
+| **Noise threshold** | Minimum relative improvement required to count as real signal. Can be overridden by Mann-Whitney U statistical significance (p < 0.05). |
+| **p-value** | Two-sided Mann-Whitney U p-value comparing baseline vs experiment samples. Shown as `p≤` when at the minimum for the sample size. |
 | **Quality gate** | Secondary metric with a hard min/max threshold that must not be violated. |
 | **Secondary metric** | Informational tracked metric shown to the agent but not used as a hard gate. |
 | **Repeats** | Number of measurement runs per experiment. AutoAuto compares medians. |

--- a/docs/measurement-guide.md
+++ b/docs/measurement-guide.md
@@ -110,7 +110,11 @@ A "3% improvement" is meaningless if your measurement varies by 5% between runs.
 
 **During execution:** Each experiment is measured N times (configurable `repeats`), and AutoAuto uses the median. This filters outliers.
 
-**Statistical significance.** With 2+ repeats, AutoAuto runs a Mann-Whitney U test (non-parametric, no normality assumption) on the raw samples and shows a p-value in the results table. The noise threshold still makes the keep/discard decision — the p-value tells you how confident that decision is. Minimum achievable p-value is 0.1 at 3 repeats and ~0.008 at 5 repeats, so use 5+ if you want p < 0.05 significance.
+**Statistical significance.** With 2+ repeats, AutoAuto runs a Mann-Whitney U test (non-parametric, no normality assumption) on the raw baseline and experiment samples. The p-value is shown in the results table alongside each experiment's status.
+
+The p-value can override the noise threshold in both directions: if a change falls within the threshold but Mann-Whitney shows the difference is statistically significant (p < 0.05), the experiment is kept (if improved) or discarded as regressed (if worsened). This prevents discarding small-but-real improvements that the threshold would otherwise filter out.
+
+Minimum achievable p-value depends on your repeat count: 0.1 at 3 repeats, ~0.029 at 4 repeats, ~0.008 at 5 repeats. With 3 repeats, the p-value override can never trigger (minimum p=0.10 > 0.05), so you need **4+ repeats** for statistical significance to influence decisions. Use 5+ repeats for strong statistical power. When the p-value hits the floor for the sample size, it's displayed as `p≤0.10` instead of `p=0.10` to indicate this is the strongest possible signal, not a weak one.
 
 **Common causes of high variance:**
 - Cold starts (add warm-up runs)

--- a/docs/patterns/loop-tuning.md
+++ b/docs/patterns/loop-tuning.md
@@ -45,8 +45,8 @@ The core keep/discard loop:
 1. Agent makes one change, commits
 2. Orchestrator measures (median of N runs)
 3. If metric improved beyond noise threshold AND quality gates pass -> **keep**
-4. If within noise threshold BUT Mann-Whitney U test says significant (p < 0.05) AND quality gates pass -> **keep** (statistical override)
-5. If metric didn't improve or a gate failed -> **discard** (`git reset --hard`)
+4. If within noise threshold, quality gates pass, and Mann-Whitney U says **significant improvement** (p < 0.05) -> **keep** (statistical override)
+5. If within noise threshold but Mann-Whitney U says **significant regression** (p < 0.05), or if metric didn't improve, or if any gate failed -> **discard** (`git reset --hard`)
 6. Loop
 
 **Design principles:**

--- a/docs/patterns/loop-tuning.md
+++ b/docs/patterns/loop-tuning.md
@@ -45,8 +45,9 @@ The core keep/discard loop:
 1. Agent makes one change, commits
 2. Orchestrator measures (median of N runs)
 3. If metric improved beyond noise threshold AND quality gates pass -> **keep**
-4. If metric didn't improve or a gate failed -> **discard** (`git reset --hard`)
-5. Loop
+4. If within noise threshold BUT Mann-Whitney U test says significant (p < 0.05) AND quality gates pass -> **keep** (statistical override)
+5. If metric didn't improve or a gate failed -> **discard** (`git reset --hard`)
+6. Loop
 
 **Design principles:**
 - **Immediate accept/revert.** No probabilistic acceptance, no batching. The codebase can only move forward.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,7 @@ import { closeProviders, type AgentProviderID } from "./lib/agent/index.ts"
 import { registerDefaultProviders } from "./lib/agent/default-providers.ts"
 import { getDefaultModel } from "./lib/model-options.ts"
 import { formatShellError } from "./lib/git.ts"
-import { formatRunDuration, formatChangePct } from "./lib/format.ts"
+import { formatRunDuration, formatChangePct, formatStatusWithP } from "./lib/format.ts"
 import {
   readQueue,
   appendToQueue,
@@ -700,7 +700,7 @@ async function cmdResults(args: ParsedArgs) {
         : formatChangePct(originalBaseline, r.metric_value, programConfig.direction)
     const num = String(r.experiment_number)
     out(
-      `${padRight(num, 5)} ${padRight(r.status, 22)} ${padRight(String(r.metric_value), 14)} ${padRight(change, 10)} ${padRight(r.commit.slice(0, 7), 10)} ${r.description}`,
+      `${padRight(num, 5)} ${padRight(formatStatusWithP(r.status, r.p_value, r.p_is_minimum), 22)} ${padRight(String(r.metric_value), 14)} ${padRight(change, 10)} ${padRight(r.commit.slice(0, 7), 10)} ${r.description}`,
     )
   }
 }

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -3,7 +3,7 @@ import { useKeyboard } from "@opentui/react"
 import type { ExperimentResult, ExperimentStatus } from "../lib/run.ts"
 import { parseSecondaryValues } from "../lib/run.ts"
 import type { SecondaryMetric } from "../lib/programs.ts"
-import { allocateColumnWidths, formatCell, type ColumnSpec } from "../lib/format.ts"
+import { allocateColumnWidths, formatCell, formatStatusWithP, type ColumnSpec } from "../lib/format.ts"
 import { colors } from "../lib/theme.ts"
 
 interface ResultsTableProps {
@@ -53,7 +53,7 @@ const ResultRow = memo(function ResultRow({ result: r, secondaryFields, highligh
     return formatCell(val != null ? String(val) : "—", columnWidths[3 + i])
   })
   const trailingCells = [
-    formatCell(r.status, columnWidths[3 + secondaryFields.length]),
+    formatCell(formatStatusWithP(r.status, r.p_value, r.p_is_minimum), columnWidths[3 + secondaryFields.length]),
     formatCell(r.description, columnWidths[4 + secondaryFields.length]),
   ]
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -229,6 +229,7 @@ export async function startDaemon(args = process.argv.slice(2)) {
         phase: "idle",
         original_baseline: baseline.median_metric,
         current_baseline: baseline.median_metric,
+        baseline_samples: baseline.metric_values,
         best_metric: baseline.median_metric,
         original_baseline_sha: fullSha,
         last_known_good_sha: fullSha,

--- a/src/lib/experiment-loop.ts
+++ b/src/lib/experiment-loop.ts
@@ -4,6 +4,7 @@ import type { RunState, ExperimentResult, TerminationReason, PreviousRunContext 
 import type { ProgramConfig } from "./programs.ts"
 import type { QuotaInfo } from "./agent/types.ts"
 import { type ModelSlot, formatModelLabel } from "./config.ts"
+import { formatPValue } from "./format.ts"
 import {
   readState,
   writeState,
@@ -21,7 +22,7 @@ import {
 } from "./git.ts"
 import {
   runMeasurementSeries,
-  compareMetric,
+  compareMetricWithSignificance,
 } from "./measure.ts"
 import type { DiffStats } from "./git.ts"
 import {
@@ -189,11 +190,13 @@ async function maybeRebaseline(
 
   if (!driftCheck.success) return state
 
-  const driftVerdict = compareMetric(
+  const { verdict: driftVerdict } = compareMetricWithSignificance(
     state.current_baseline,
     driftCheck.median_metric,
     config.noise_threshold,
     config.direction,
+    state.baseline_samples,
+    driftCheck.metric_values,
   )
 
   if (driftVerdict === "noise") return state
@@ -202,6 +205,7 @@ async function maybeRebaseline(
   const newState: RunState = {
     ...state,
     current_baseline: driftCheck.median_metric,
+    baseline_samples: driftCheck.metric_values,
     updated_at: now(),
   }
   await writeState(runDir, newState)
@@ -309,12 +313,14 @@ async function runMeasurementAndDecide(
     return { state: finalState, kept: false, diagnostics: series.diagnostics }
   }
 
-  // 4. Compare against baseline
-  const verdict = compareMetric(
+  // 4. Compare against baseline (with statistical significance)
+  const { verdict, p_value, p_is_minimum } = compareMetricWithSignificance(
     state.current_baseline,
     series.median_metric,
     config.noise_threshold,
     config.direction,
+    state.baseline_samples,
+    series.metric_values,
   )
 
   // 5. Check for simplification auto-keep: net-negative LOC within noise
@@ -328,7 +334,8 @@ async function runMeasurementAndDecide(
     // KEEP (metric improvement or simplification)
     const keepReason = isSimplification ? "simplification" : "keep"
     const keepDesc = isSimplification ? `simplification: ${description}` : description
-    callbacks.onPhaseChange("kept", `${keepReason}: ${state.current_baseline} → ${series.median_metric}`)
+    const pLabel = p_value != null ? ` (${formatPValue(p_value, p_is_minimum)})` : ""
+    callbacks.onPhaseChange("kept", `${keepReason}: ${state.current_baseline} → ${series.median_metric}${pLabel}`)
 
     const isBest = !isSimplification && (config.direction === "lower"
       ? series.median_metric < state.best_metric
@@ -343,6 +350,8 @@ async function runMeasurementAndDecide(
       description: keepDesc,
       measurement_duration_ms: series.duration_ms,
       diff_stats: diffStatsStr,
+      p_value,
+      p_is_minimum,
     }
     await appendResult(runDir, result)
     await recordBacklog(result)
@@ -352,6 +361,7 @@ async function runMeasurementAndDecide(
     callbacks.onPhaseChange("measuring", `re-baselining after ${keepReason}`)
     const rebaseline = await runMeasurementSeries(measureShPath, cwd, config, signal, buildShPath)
     const newBaseline = rebaseline.success ? rebaseline.median_metric : series.median_metric
+    const newBaselineSamples = rebaseline.success ? rebaseline.metric_values : series.metric_values
 
     if (rebaseline.success && newBaseline !== series.median_metric) {
       callbacks.onRebaseline?.(series.median_metric, newBaseline, keepReason)
@@ -361,6 +371,7 @@ async function runMeasurementAndDecide(
       ...currentState,
       total_keeps: currentState.total_keeps + 1,
       current_baseline: newBaseline,
+      baseline_samples: newBaselineSamples,
       best_metric: isBest ? series.median_metric : currentState.best_metric,
       best_experiment: isBest ? state.experiment_number : currentState.best_experiment,
       last_known_good_sha: candidateSha,
@@ -374,7 +385,8 @@ async function runMeasurementAndDecide(
 
   // DISCARD (regressed or noise without simplification)
   const reason = verdict === "regressed" ? "regressed" : "within noise"
-  callbacks.onPhaseChange("reverting", `${reason}: ${state.current_baseline} → ${series.median_metric}`)
+  const pLabel = p_value != null ? ` (${formatPValue(p_value, p_is_minimum)})` : ""
+  callbacks.onPhaseChange("reverting", `${reason}: ${state.current_baseline} → ${series.median_metric}${pLabel}`)
 
   currentState = { ...currentState, phase: "reverting", updated_at: now() }
   await writeState(runDir, currentState)
@@ -392,6 +404,7 @@ async function runMeasurementAndDecide(
     description: statusDesc,
     measurement_duration_ms: series.duration_ms,
     diff_stats: diffStatsStr,
+    p_value,
   }
   await appendResult(runDir, result)
   await recordBacklog(result)

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { allocateColumnWidths, formatCell, padRight, truncate } from "./format.ts"
+import { allocateColumnWidths, formatCell, formatPValue, formatStatusWithP, padRight, truncate } from "./format.ts"
 
 describe("format helpers", () => {
   test("handles zero and one character widths", () => {
@@ -33,5 +33,43 @@ describe("format helpers", () => {
     expect(allocateColumnWidths(0, [
       { ideal: 1, min: 4 },
     ])).toEqual([0])
+  })
+})
+
+describe("formatPValue", () => {
+  test("formats normal p-values with p= prefix", () => {
+    expect(formatPValue(0.05)).toBe("p=0.05")
+    expect(formatPValue(0.10)).toBe("p=0.10")
+    expect(formatPValue(0.50)).toBe("p=0.50")
+  })
+
+  test("uses exponential notation for small p-values", () => {
+    expect(formatPValue(0.008)).toBe("p=8.0e-3")
+    expect(formatPValue(0.001)).toBe("p=1.0e-3")
+  })
+
+  test("uses ≤ prefix when p is at minimum", () => {
+    expect(formatPValue(0.10, true)).toBe("p≤0.10")
+    expect(formatPValue(0.008, true)).toBe("p≤8.0e-3")
+  })
+
+  test("uses = prefix when isMinimum is false or undefined", () => {
+    expect(formatPValue(0.10, false)).toBe("p=0.10")
+    expect(formatPValue(0.10)).toBe("p=0.10")
+  })
+})
+
+describe("formatStatusWithP", () => {
+  test("appends p-value to status", () => {
+    expect(formatStatusWithP("keep", 0.03)).toBe("keep p=0.03")
+  })
+
+  test("shows ≤ for minimum p-values", () => {
+    expect(formatStatusWithP("keep", 0.10, true)).toBe("keep p≤0.10")
+  })
+
+  test("returns bare status when no p-value", () => {
+    expect(formatStatusWithP("keep")).toBe("keep")
+    expect(formatStatusWithP("discard", undefined)).toBe("discard")
   })
 })

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -104,6 +104,20 @@ export function formatRunDuration(startedAt: string, endedAt?: string): string {
   return formatDurationMs(end - start)
 }
 
+/** Format p-value for display: exponential notation for small values, 2 decimal places otherwise.
+ *  When isMinimum is true, uses "p≤" to indicate this is the lowest attainable p-value
+ *  for the sample sizes used (e.g. "p≤0.10" with 3 repeats means complete separation — strongest
+ *  possible signal, but more repeats needed to reach conventional p<0.05 significance). */
+export function formatPValue(p: number, isMinimum?: boolean): string {
+  const formatted = p < 0.01 ? p.toExponential(1) : p.toFixed(2)
+  return `p${isMinimum ? "≤" : "="}${formatted}`
+}
+
+/** Format status with optional p-value suffix, e.g. "keep p=0.03" or "keep p≤0.10" */
+export function formatStatusWithP(status: string, p_value?: number, p_is_minimum?: boolean): string {
+  return p_value != null ? `${status} ${formatPValue(p_value, p_is_minimum)}` : status
+}
+
 /** Format metric change as a signed percentage string. */
 export function formatChangePct(
   original: number,

--- a/src/lib/measure.test.ts
+++ b/src/lib/measure.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   compareMetric,
+  compareMetricWithSignificance,
   checkQualityGates,
   validateMeasurementOutput,
   runMeasurement,
@@ -78,6 +79,112 @@ describe("compareMetric", () => {
       expect(compareMetric(100, 101, 0, "lower")).toBe("regressed")
       // Equal stays noise (0 > 0 is false)
       expect(compareMetric(100, 100, 0, "lower")).toBe("noise")
+    })
+  })
+})
+
+// --- compareMetricWithSignificance ---
+
+describe("compareMetricWithSignificance", () => {
+  test("returns verdict without p_value when no samples provided", () => {
+    const result = compareMetricWithSignificance(100, 90, 0.02, "lower")
+    expect(result.verdict).toBe("keep")
+    expect(result.p_value).toBeUndefined()
+  })
+
+  test("returns verdict without p_value when samples too small", () => {
+    const result = compareMetricWithSignificance(100, 90, 0.02, "lower", [100], [90])
+    expect(result.verdict).toBe("keep")
+    expect(result.p_value).toBeUndefined()
+  })
+
+  test("returns p_value when both samples have ≥ 2 values", () => {
+    const result = compareMetricWithSignificance(
+      100, 90, 0.02, "lower",
+      [100, 102, 98], [90, 92, 88],
+    )
+    expect(result.verdict).toBe("keep")
+    expect(result.p_value).toBeDefined()
+    expect(result.p_value!).toBeGreaterThan(0)
+    expect(result.p_value!).toBeLessThanOrEqual(1)
+  })
+
+  test("clear separation gives low p_value", () => {
+    const result = compareMetricWithSignificance(
+      100, 80, 0.02, "lower",
+      [99, 100, 101, 102, 98], [79, 80, 81, 82, 78],
+    )
+    expect(result.verdict).toBe("keep")
+    expect(result.p_value!).toBeLessThan(0.05)
+  })
+
+  test("overlapping samples give high p_value even with threshold keep", () => {
+    // Medians differ enough for threshold, but individual samples overlap heavily
+    const result = compareMetricWithSignificance(
+      100, 95, 0.02, "lower",
+      [95, 100, 105], [90, 95, 100],
+    )
+    expect(result.verdict).toBe("keep")
+    // Overlap means high p_value — the improvement may not be statistically significant
+    expect(result.p_value!).toBeGreaterThan(0.1)
+  })
+
+  describe("p-value override of noise threshold", () => {
+    test("overrides noise → keep when improvement is statistically significant", () => {
+      // 3% improvement below 5% threshold, but completely separated samples (n=5)
+      const result = compareMetricWithSignificance(
+        100, 97, 0.05, "lower",
+        [99, 100, 101, 102, 103], [94, 95, 96, 97, 98],
+      )
+      // Threshold: 3% < 5% → "noise"
+      // Mann-Whitney: complete separation → p ≈ 0.008 < 0.05 → override to "keep"
+      expect(result.verdict).toBe("keep")
+      expect(result.p_value!).toBeLessThan(0.05)
+    })
+
+    test("overrides noise → regressed when worsening is statistically significant", () => {
+      // 3% regression below 5% threshold, but completely separated samples (n=5)
+      const result = compareMetricWithSignificance(
+        100, 103, 0.05, "lower",
+        [98, 99, 100, 101, 102], [103, 104, 105, 106, 107],
+      )
+      // Threshold: -3% > -5% → "noise"
+      // Mann-Whitney: complete separation → p < 0.05 → override to "regressed"
+      expect(result.verdict).toBe("regressed")
+      expect(result.p_value!).toBeLessThan(0.05)
+    })
+
+    test("stays noise when p >= 0.05 despite being within threshold", () => {
+      // Small change, heavily overlapping samples → p > 0.05 → no override
+      const result = compareMetricWithSignificance(
+        100, 99, 0.05, "lower",
+        [97, 100, 103], [96, 99, 102],
+      )
+      expect(result.verdict).toBe("noise")
+      expect(result.p_value!).toBeGreaterThan(0.05)
+    })
+
+    test("no override with n=3 (minimum p=0.10 > 0.05)", () => {
+      // Complete separation with n=3 → p = 0.10, which is > 0.05
+      // So even though samples are perfectly separated, can't reach significance
+      const result = compareMetricWithSignificance(
+        100, 97, 0.05, "lower",
+        [100, 101, 102], [94, 95, 96],
+      )
+      expect(result.verdict).toBe("noise")
+      expect(result.p_value!).toBeCloseTo(0.1, 4)
+    })
+
+    test("override works with direction=higher", () => {
+      // 3% improvement below 5% threshold, higher is better
+      const result = compareMetricWithSignificance(
+        100, 103, 0.05, "higher",
+        [98, 99, 100, 101, 102], [103, 104, 105, 106, 107],
+      )
+      // Threshold: 3% < 5% → "noise"
+      // Mann-Whitney: separated → p < 0.05 → override to "keep"
+      expect(result.verdict).toBe("keep")
+      expect(result.p_value!).toBeLessThan(0.05)
     })
   })
 })
@@ -365,6 +472,7 @@ esac
     expect(result.success).toBe(true)
     expect(result.median_metric).toBe(20) // median of [10, 30, 20] = 20
     expect(result.individual_runs).toHaveLength(3)
+    expect(result.metric_values).toEqual([10, 30, 20])
   })
 
   test("fails when any repeat fails", async () => {

--- a/src/lib/measure.ts
+++ b/src/lib/measure.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process"
 import { join } from "node:path"
 import { unlink } from "node:fs/promises"
 import type { ProgramConfig } from "./programs.ts"
+import { mannWhitneyU } from "./stats.ts"
 
 // --- Helpers ---
 
@@ -24,6 +25,8 @@ export type MeasurementResult =
 export interface MeasurementSeriesResult {
   success: boolean
   median_metric: number
+  /** Raw metric values from each successful repeat (for statistical tests) */
+  metric_values: number[]
   median_quality_gates: Record<string, number>
   median_secondary_metrics: Record<string, number>
   quality_gates_passed: boolean
@@ -352,6 +355,7 @@ export async function runMeasurementSeries(
       return {
         success: false,
         median_metric: 0,
+        metric_values: [],
         median_quality_gates: {},
         median_secondary_metrics: {},
         quality_gates_passed: false,
@@ -394,6 +398,7 @@ export async function runMeasurementSeries(
     return {
       success: false,
       median_metric: 0,
+      metric_values: [],
       median_quality_gates: {},
       median_secondary_metrics: {},
       quality_gates_passed: false,
@@ -418,6 +423,7 @@ export async function runMeasurementSeries(
     return {
       success: false,
       median_metric: 0,
+      metric_values: [],
       median_quality_gates: {},
       median_secondary_metrics: {},
       quality_gates_passed: false,
@@ -441,6 +447,7 @@ export async function runMeasurementSeries(
   return {
     success: true,
     median_metric: medianMetric,
+    metric_values: validMetrics,
     median_quality_gates: medianGates,
     median_secondary_metrics: medianSecondary,
     quality_gates_passed: gateCheck.passed,
@@ -471,4 +478,71 @@ export function compareMetric(
   if (relativeChange > noiseThreshold) return "keep"
   if (relativeChange < -noiseThreshold) return "regressed"
   return "noise"
+}
+
+// --- Comparison with statistical significance ---
+
+/** Significance level for p-value override of noise threshold */
+const SIGNIFICANCE_ALPHA = 0.05
+
+export interface ComparisonResult {
+  verdict: "keep" | "regressed" | "noise"
+  /** Two-sided p-value from Mann-Whitney U test (undefined if samples too small) */
+  p_value?: number
+  /** True when p_value is the minimum attainable for these sample sizes (need more repeats for lower p) */
+  p_is_minimum?: boolean
+}
+
+/**
+ * Compares metric with both threshold check and statistical significance.
+ *
+ * Decision logic:
+ * 1. If the change exceeds noise_threshold → keep or regressed (as before)
+ * 2. If within threshold BUT Mann-Whitney p < 0.05 → the difference is
+ *    statistically real despite being small, so override:
+ *    - improvement direction → keep
+ *    - regression direction → regressed
+ * 3. Otherwise → noise
+ *
+ * This means small-but-real improvements get kept instead of discarded.
+ * Requires ≥ 2 samples in each group for significance testing.
+ */
+export function compareMetricWithSignificance(
+  baseline: number,
+  measured: number,
+  noiseThreshold: number,
+  direction: "lower" | "higher",
+  baselineSamples?: number[],
+  measuredSamples?: number[],
+): ComparisonResult {
+  const verdict = compareMetric(baseline, measured, noiseThreshold, direction)
+
+  if (!baselineSamples?.length || !measuredSamples?.length
+    || baselineSamples.length < 2 || measuredSamples.length < 2) {
+    return { verdict }
+  }
+
+  const test = mannWhitneyU(baselineSamples, measuredSamples)
+  if (!test) return { verdict }
+
+  // If threshold already decided (keep or regressed), just attach the p-value
+  if (verdict !== "noise") {
+    return { verdict, p_value: test.p, p_is_minimum: test.isMinimum }
+  }
+
+  // Threshold says "noise" — check if Mann-Whitney disagrees
+  if (test.p < SIGNIFICANCE_ALPHA) {
+    const relativeChange = direction === "lower"
+      ? (baseline - measured) / baseline
+      : (measured - baseline) / baseline
+
+    if (relativeChange > 0) {
+      return { verdict: "keep", p_value: test.p, p_is_minimum: test.isMinimum }
+    }
+    if (relativeChange < 0) {
+      return { verdict: "regressed", p_value: test.p, p_is_minimum: test.isMinimum }
+    }
+  }
+
+  return { verdict: "noise", p_value: test.p, p_is_minimum: test.isMinimum }
 }

--- a/src/lib/run-setup.ts
+++ b/src/lib/run-setup.ts
@@ -27,7 +27,7 @@ export async function initRunDir(programDir: string, runId: string): Promise<str
 
   await Bun.write(
     join(runDir, "results.tsv"),
-    "experiment#\tcommit\tmetric_value\tsecondary_values\tstatus\tdescription\tmeasurement_duration_ms\tdiff_stats\n",
+    "experiment#\tcommit\tmetric_value\tsecondary_values\tstatus\tdescription\tmeasurement_duration_ms\tdiff_stats\tp_value\tp_min\n",
   )
 
   return runDir

--- a/src/lib/run.ts
+++ b/src/lib/run.ts
@@ -66,6 +66,8 @@ export interface RunState {
   error?: string | null
   /** Which phase the error occurred in */
   error_phase?: RunPhase | null
+  /** Individual metric values from the most recent baseline measurement (for Mann-Whitney U test) */
+  baseline_samples?: number[]
   /** Whether this run was started manually or from the queue */
   source?: "manual" | "queue"
   /** ISO timestamp of when finalization completed */
@@ -93,6 +95,10 @@ export interface ExperimentResult {
   measurement_duration_ms: number
   /** Diff stats JSON — e.g. {"lines_added":12,"lines_removed":5}. Absent for old runs. */
   diff_stats?: string
+  /** Two-sided p-value from Mann-Whitney U test comparing baseline vs experiment samples */
+  p_value?: number
+  /** True when p_value is the minimum attainable for the sample sizes (complete separation) */
+  p_is_minimum?: boolean
 }
 
 /** Structured secondary values stored in results.tsv */
@@ -167,7 +173,9 @@ export async function readState(runDir: string): Promise<RunState> {
 export async function appendResult(runDir: string, result: ExperimentResult): Promise<void> {
   const secondaryStr = result.secondary_values || ""
   const diffStatsStr = result.diff_stats || ""
-  const line = `${result.experiment_number}\t${result.commit}\t${result.metric_value}\t${secondaryStr}\t${result.status}\t${result.description}\t${result.measurement_duration_ms}\t${diffStatsStr}\n`
+  const pValueStr = result.p_value != null ? String(result.p_value) : ""
+  const pMinStr = result.p_is_minimum ? "1" : ""
+  const line = `${result.experiment_number}\t${result.commit}\t${result.metric_value}\t${secondaryStr}\t${result.status}\t${result.description}\t${result.measurement_duration_ms}\t${diffStatsStr}\t${pValueStr}\t${pMinStr}\n`
   await appendFile(join(runDir, "results.tsv"), line)
 }
 
@@ -177,6 +185,7 @@ export async function appendResult(runDir: string, result: ExperimentResult): Pr
 function parseTsvRow(line: string): ExperimentResult | null {
   const parts = line.split("\t")
   if (parts.length < 6) return null
+  const pv = parts[8] ? parseFloat(parts[8]) : undefined
   return {
     experiment_number: parseInt(parts[0], 10),
     commit: parts[1],
@@ -186,6 +195,8 @@ function parseTsvRow(line: string): ExperimentResult | null {
     description: parts[5],
     measurement_duration_ms: parts[6] ? parseInt(parts[6], 10) : 0,
     diff_stats: parts[7] || undefined,
+    p_value: pv != null && isFinite(pv) ? pv : undefined,
+    p_is_minimum: parts[9] === "1" ? true : undefined,
   }
 }
 

--- a/src/lib/stats.test.ts
+++ b/src/lib/stats.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect } from "bun:test"
+import { mannWhitneyU } from "./stats.ts"
+
+describe("mannWhitneyU", () => {
+  test("returns null when either sample has fewer than 2 values", () => {
+    expect(mannWhitneyU([1], [2, 3])).toBeNull()
+    expect(mannWhitneyU([1, 2], [3])).toBeNull()
+    expect(mannWhitneyU([], [1, 2])).toBeNull()
+  })
+
+  describe("exact p-values (small samples, no ties)", () => {
+    test("interleaved distributions give high p and isMinimum=false", () => {
+      const result = mannWhitneyU([1, 3, 5], [2, 4, 6])!
+      expect(result.p).toBeGreaterThan(0.5)
+      expect(result.isMinimum).toBe(false)
+    })
+
+    test("completely separated samples give minimum p-value with isMinimum flag", () => {
+      // All of A < all of B → U = 0 → minimum p
+      // For n1=n2=3, minimum p = 2 * 1/20 = 0.1
+      const result = mannWhitneyU([1, 2, 3], [4, 5, 6])!
+      expect(result.U).toBe(0)
+      expect(result.p).toBeCloseTo(0.1, 4)
+      expect(result.isMinimum).toBe(true)
+    })
+
+    test("known n=3,3 U=1 gives p=0.2", () => {
+      // U_a: 1 beats none of B (0), 2 beats none (0), 3 beats 1 of B (just the value 2 wait...
+      // Let me construct carefully: A=[1,2,4], B=[3,5,6]
+      // U_a: 1>3? no. 1>5? no. 1>6? no. → 0
+      //       2>3? no. 2>5? no. 2>6? no. → 0
+      //       4>3? yes. 4>5? no. 4>6? no. → 1
+      // U_a = 1, U_b = 9 - 1 = 8, U = min(1, 8) = 1
+      const result = mannWhitneyU([1, 2, 4], [3, 5, 6])!
+      expect(result.U).toBe(1)
+      expect(result.p).toBeCloseTo(0.2, 4)
+    })
+
+    test("larger samples give more discriminating p-values", () => {
+      // n=5 vs n=5, complete separation → U = 0
+      // C(10,5) = 252, p = 2/252 ≈ 0.00794
+      const result = mannWhitneyU([1, 2, 3, 4, 5], [6, 7, 8, 9, 10])!
+      expect(result.U).toBe(0)
+      expect(result.p).toBeCloseTo(2 / 252, 4)
+    })
+
+    test("n=5 equal overlap gives high p-value", () => {
+      const result = mannWhitneyU([1, 3, 5, 7, 9], [2, 4, 6, 8, 10])!
+      expect(result.p).toBeGreaterThan(0.5)
+    })
+  })
+
+  describe("samples with ties (normal approximation)", () => {
+    test("handles tied values between samples", () => {
+      const result = mannWhitneyU([1, 2, 3], [3, 4, 5])!
+      expect(result).not.toBeNull()
+      expect(result.p).toBeGreaterThan(0)
+      expect(result.p).toBeLessThanOrEqual(1)
+    })
+
+    test("identical samples give p = 1", () => {
+      const result = mannWhitneyU([5, 5, 5], [5, 5, 5])!
+      // U = 4.5 (half of 3*3), everything tied
+      expect(result.p).toBe(1)
+    })
+
+    test("clear separation with ties gives low p-value", () => {
+      // Groups clearly differ despite some tied values
+      // scipy.stats.mannwhitneyu([1,1,2,2,3], [4,4,5,5,6]) → p ≈ 0.0122 (two-sided)
+      const result = mannWhitneyU([1, 1, 2, 2, 3], [4, 4, 5, 5, 6])!
+      expect(result.U).toBe(0)
+      expect(result.p).toBeLessThan(0.02)
+      expect(result.p).toBeGreaterThan(0.005)
+    })
+
+    test("partial overlap with ties gives moderate p-value", () => {
+      // Some overlap: A=[1,2,3,3,4], B=[3,3,4,5,6]
+      const result = mannWhitneyU([1, 2, 3, 3, 4], [3, 3, 4, 5, 6])!
+      expect(result.p).toBeGreaterThan(0.05)
+      expect(result.p).toBeLessThan(0.5)
+    })
+  })
+
+  describe("real-world measurement scenarios", () => {
+    test("clear improvement: baseline ~100, experiment ~90 (lower is better)", () => {
+      const baseline = [100, 102, 98, 101, 99]
+      const experiment = [90, 92, 88, 91, 89]
+      const result = mannWhitneyU(baseline, experiment)!
+      // Completely separated → very low p-value
+      expect(result.p).toBeLessThan(0.05)
+    })
+
+    test("marginal improvement: overlapping distributions", () => {
+      const baseline = [100, 102, 98, 101, 99]
+      const experiment = [97, 99, 95, 101, 96]
+      const result = mannWhitneyU(baseline, experiment)!
+      // Mostly separated with some overlap → moderate p
+      expect(result.p).toBeGreaterThan(0.01)
+    })
+
+    test("no real difference: same distribution", () => {
+      const baseline = [100, 102, 98, 101, 99]
+      const experiment = [100, 101, 99, 102, 98]
+      const result = mannWhitneyU(baseline, experiment)!
+      expect(result.p).toBeGreaterThan(0.5)
+    })
+
+    test("works with repeats=3 (limited power)", () => {
+      const baseline = [100, 102, 98]
+      const experiment = [90, 92, 88]
+      const result = mannWhitneyU(baseline, experiment)!
+      // Complete separation with n=3 → p = 0.1 (minimum possible)
+      expect(result.U).toBe(0)
+      expect(result.p).toBeCloseTo(0.1, 4)
+    })
+  })
+
+  describe("symmetry", () => {
+    test("swapping samples gives same p-value", () => {
+      const a = [1, 3, 5, 7]
+      const b = [2, 4, 6, 8]
+      const r1 = mannWhitneyU(a, b)!
+      const r2 = mannWhitneyU(b, a)!
+      expect(r1.p).toBeCloseTo(r2.p, 10)
+      expect(r1.U).toBeCloseTo(r2.U, 10)
+    })
+  })
+})

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,172 @@
+/**
+ * Statistical significance tests for measurement comparison.
+ *
+ * Mann-Whitney U test: non-parametric test comparing two independent samples.
+ * Does not assume normal distribution — suitable for noisy, skewed, or
+ * discrete measurements.
+ */
+
+export interface MannWhitneyResult {
+  /** The U statistic (min of U_a and U_b) */
+  U: number
+  /** Two-sided p-value */
+  p: number
+  /** True when p is the minimum attainable for these sample sizes (U=0, complete separation) */
+  isMinimum: boolean
+}
+
+/**
+ * Mann-Whitney U test (two-sided, non-parametric).
+ *
+ * Tests whether two independent samples come from the same distribution.
+ * Returns null if either sample has fewer than 2 values.
+ *
+ * Uses exact distribution via DP for small samples (n1+n2 ≤ 40),
+ * normal approximation with continuity correction and tie adjustment otherwise.
+ */
+export function mannWhitneyU(
+  sampleA: number[],
+  sampleB: number[],
+): MannWhitneyResult | null {
+  const n1 = sampleA.length
+  const n2 = sampleB.length
+  if (n1 < 2 || n2 < 2) return null
+
+  // Compute U_a via pairwise comparison
+  let Ua = 0
+  for (const a of sampleA) {
+    for (const b of sampleB) {
+      if (a > b) Ua++
+      else if (a === b) Ua += 0.5
+    }
+  }
+  const Ub = n1 * n2 - Ua
+  const U = Math.min(Ua, Ub)
+
+  const combined = [...sampleA, ...sampleB]
+  const hasTies = checkTies(combined)
+
+  const isMinimum = U === 0
+
+  if (n1 + n2 <= 40 && !hasTies) {
+    const p = exactPValue(U, n1, n2)
+    return { U, p, isMinimum }
+  }
+
+  // Normal approximation with tie correction and continuity correction
+  const N = n1 + n2
+  const mean = (n1 * n2) / 2
+
+  let variance: number
+  if (hasTies) {
+    const tieGroups = getTieGroupSizes(combined)
+    const tieSum = tieGroups.reduce((s, t) => s + (t * t * t - t), 0)
+    variance = ((n1 * n2) / 12) * (N + 1 - tieSum / (N * (N - 1)))
+  } else {
+    variance = (n1 * n2 * (N + 1)) / 12
+  }
+
+  if (variance <= 0) return { U, p: 1, isMinimum: false }
+
+  const z = (Math.abs(U - mean) - 0.5) / Math.sqrt(variance)
+  const p = Math.min(2 * (1 - normalCDF(z)), 1)
+
+  return { U, p, isMinimum }
+}
+
+// --- Internal helpers ---
+
+function checkTies(values: number[]): boolean {
+  const seen = new Set<number>()
+  for (const v of values) {
+    if (seen.has(v)) return true
+    seen.add(v)
+  }
+  return false
+}
+
+function getTieGroupSizes(values: number[]): number[] {
+  const counts = new Map<number, number>()
+  for (const v of values) {
+    counts.set(v, (counts.get(v) ?? 0) + 1)
+  }
+  return [...counts.values()].filter((c) => c > 1)
+}
+
+/**
+ * Exact two-sided p-value for Mann-Whitney U via DP.
+ * Only valid for the no-ties case.
+ *
+ * Uses the recurrence: f(u, m, n) = f(u-n, m-1, n) + f(u, m, n-1)
+ * where f(u, m, n) = number of rank permutations giving U_a = u
+ * with m elements from sample A and n from sample B.
+ */
+function exactPValue(U: number, n1: number, n2: number): number {
+  const memo = new Map<number, number>()
+
+  // Pack (u, m, n) into a single key. u ∈ [0, n1*n2], m ∈ [0, n1], n ∈ [0, n2]
+  const stride_m = (n1 * n2 + 1)
+  const stride_n = stride_m * (n1 + 1)
+
+  function f(u: number, m: number, n: number): number {
+    if (u < 0) return 0
+    if (m === 0 || n === 0) return u === 0 ? 1 : 0
+
+    const key = u + m * stride_m + n * stride_n
+    const cached = memo.get(key)
+    if (cached !== undefined) return cached
+
+    const result = f(u - n, m - 1, n) + f(u, m, n - 1)
+    memo.set(key, result)
+    return result
+  }
+
+  // Total arrangements = C(n1+n2, n1)
+  const total = binomial(n1 + n2, n1)
+
+  // Cumulative probability: P(U_a ≤ U_observed)
+  const floorU = Math.floor(U)
+  let cumulative = 0
+  for (let u = 0; u <= floorU; u++) {
+    cumulative += f(u, n1, n2)
+  }
+
+  // Two-sided p-value
+  return Math.min((2 * cumulative) / total, 1)
+}
+
+function binomial(n: number, k: number): number {
+  if (k < 0 || k > n) return 0
+  if (k === 0 || k === n) return 1
+  k = Math.min(k, n - k)
+  let result = 1
+  for (let i = 0; i < k; i++) {
+    result = (result * (n - i)) / (i + 1)
+  }
+  return Math.round(result)
+}
+
+/**
+ * Normal CDF approximation via erf (Abramowitz & Stegun 7.1.26).
+ * Phi(x) = 0.5 * (1 + erf(x / sqrt(2))), where the erf coefficients
+ * require the x/sqrt(2) substitution. Accurate to ~1.5e-7 for all x.
+ */
+function normalCDF(x: number): number {
+  if (x < -8) return 0
+  if (x > 8) return 1
+
+  const a1 = 0.254829592
+  const a2 = -0.284496736
+  const a3 = 1.421413741
+  const a4 = -1.453152027
+  const a5 = 1.061405429
+  const p = 0.3275911
+
+  const sign = x < 0 ? -1 : 1
+  const z = Math.abs(x) / Math.SQRT2
+  const t = 1 / (1 + p * z)
+  const y =
+    1 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-z * z)
+
+  return 0.5 * (1 + sign * y)
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1508,6 +1508,8 @@ server.registerTool(
         commit: r.commit.slice(0, 7),
         description: r.description,
         diff_stats: r.diff_stats ?? null,
+        p_value: r.p_value ?? null,
+        p_is_minimum: r.p_is_minimum ?? false,
       })),
     })
   },


### PR DESCRIPTION
## Summary

- Adds non-parametric Mann-Whitney U test to experiment comparison — p-value can now override the noise threshold, keeping small-but-real improvements that would previously be discarded as noise
- Two-layer decision: threshold is the fast path (unchanged), Mann-Whitney catches statistically significant changes within the threshold (p < 0.05)
- Surfaces p-value in TUI results table (`keep p=0.03`), CLI, and MCP server; shows `p≤0.10` when at sample-size floor

## How it works

| Threshold says | p-value says | Result |
|---|---|---|
| keep (> threshold) | any | **keep** |
| regressed (< -threshold) | any | **regressed** |
| noise (within threshold) | p ≥ 0.05 or unavailable | **noise** (discard) |
| noise (within threshold) | p < 0.05, improvement | **keep** (override) |
| noise (within threshold) | p < 0.05, regression | **regressed** (override) |

With `repeats=3`, minimum p=0.10 so the override never triggers — need 4+ repeats for statistical significance to influence decisions. This is a natural safeguard.

## Changes

- **New:** `src/lib/stats.ts` — Mann-Whitney U (exact DP for small n, normal approx with tie correction for large n)
- **Modified:** `src/lib/measure.ts` — `compareMetricWithSignificance()`, `metric_values` in series result
- **Modified:** `src/lib/run.ts` — `baseline_samples` in RunState, `p_value`/`p_is_minimum` in ExperimentResult
- **Modified:** `src/lib/experiment-loop.ts` — wired up significance testing, stores/updates baseline samples
- **Modified:** Display layer (ResultsTable, CLI, MCP) — surfaces p-value
- **Docs:** Updated concepts, measurement guide, glossary, loop-tuning, architecture

## Test plan

- [ ] 227 unit tests pass (25+ new for stats, significance, format)
- [ ] E2E experiment-loop and MCP server tests pass (283 total)
- [ ] Typecheck clean
- [ ] Backward compatible: old runs without `baseline_samples`/`p_value` work (fields are optional, parser handles missing columns)
- [ ] Manual: run a program with `repeats=5`, verify p-values appear in results table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mann-Whitney U significance testing added to metric comparisons.
  * P-values shown alongside experiment status (with minimum-achievable notation).
  * Decision logic updated: statistical significance (p < 0.05) can override noise-threshold keep/discard outcomes; baseline sample storage enables these tests.

* **Documentation**
  * Architecture, concepts, glossary, measurement guide, and patterns updated to describe significance-aware decision rules and p-value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->