### PR TITLE
feat(sandbox): forward agent configs and subscription auth into containers

### DIFF
--- a/src/lib/agent-config.ts
+++ b/src/lib/agent-config.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared sandbox container configuration — env vars, auth checks, and
+ * agent config directory discovery (Codex, OpenCode).
+ *
+ * Claude subscription auth uses CLAUDE_CODE_OAUTH_TOKEN env var
+ * (credentials live in macOS Keychain, not on disk).
+ */
+
+import { join, relative } from "node:path"
+import { homedir } from "node:os"
+import { existsSync } from "node:fs"
+import { readdir } from "node:fs/promises"
+
+/** Where agent config lives inside the container (runs as root). */
+const CONTAINER_HOME = "/root"
+
+/** Max file size to upload (skip large caches). */
+const MAX_FILE_SIZE = 1_000_000 // 1 MB
+
+/**
+ * Resolve agent config directories as absolute host paths + container names.
+ * Respects CODEX_HOME for custom Codex locations.
+ */
+function getAgentConfigSourceDirs(): Array<{ hostPath: string; containerName: string }> {
+  const home = homedir()
+  return [
+    { hostPath: process.env.CODEX_HOME ?? join(home, ".codex"), containerName: ".codex" },
+    { hostPath: join(home, ".config/opencode"), containerName: ".config/opencode" },
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Env vars forwarded into sandbox containers
+// ---------------------------------------------------------------------------
+
+/** Env var keys forwarded into sandbox containers. */
+const CONTAINER_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+] as const
+
+export type AgentAuthMethod = "api_key" | "oauth_token"
+
+/**
+ * Check whether agent auth credentials are available for sandbox runs.
+ */
+export function checkAgentAuth(): { ok: true; authMethod: AgentAuthMethod } | { ok: false; error: string } {
+  if (process.env.ANTHROPIC_API_KEY) return { ok: true, authMethod: "api_key" }
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) return { ok: true, authMethod: "oauth_token" }
+
+  return {
+    ok: false,
+    error: "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN required — the experiment agent runs inside the container. Run `claude setup-token` to generate a subscription token.",
+  }
+}
+
+/**
+ * Collect env vars that should be forwarded into sandbox containers.
+ * Only includes keys that are actually set.
+ */
+export function collectContainerEnv(): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const key of CONTAINER_ENV_KEYS) {
+    if (process.env[key]) env[key] = process.env[key]!
+  }
+  return env
+}
+
+// ---------------------------------------------------------------------------
+// Config directory discovery
+// ---------------------------------------------------------------------------
+
+export interface ConfigFileEntry {
+  localPath: string
+  remotePath: string
+}
+
+export interface ConfigDirMount {
+  hostPath: string
+  containerPath: string
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = join(dir, entry.name)
+      if (entry.isDirectory()) return listFilesRecursive(fullPath)
+      if (entry.isFile()) return [fullPath]
+      return []
+    }),
+  )
+  return nested.flat()
+}
+
+/**
+ * Returns agent config directories that exist on the host.
+ * Used by the Docker provider for read-only bind mounts.
+ */
+export function getAgentConfigDirs(): ConfigDirMount[] {
+  return getAgentConfigSourceDirs()
+    .filter(({ hostPath }) => existsSync(hostPath))
+    .map(({ hostPath, containerName }) => ({
+      hostPath,
+      containerPath: `${CONTAINER_HOME}/${containerName}`,
+    }))
+}
+
+/**
+ * Discover agent config files for upload to sandbox containers.
+ * Skips files larger than 1 MB to avoid uploading caches.
+ */
+export async function getAgentConfigFiles(): Promise<ConfigFileEntry[]> {
+  const dirs = getAgentConfigSourceDirs()
+
+  const nested = await Promise.all(
+    dirs.map(async ({ hostPath, containerName }) => {
+      const files = await listFilesRecursive(hostPath)
+
+      return files
+        .filter((localPath) => Bun.file(localPath).size <= MAX_FILE_SIZE)
+        .map((localPath) => ({
+          localPath,
+          remotePath: `${CONTAINER_HOME}/${containerName}/${relative(hostPath, localPath)}`,
+        }))
+    }),
+  )
+
+  return nested.flat()
+}

--- a/src/lib/container-provider/docker.ts
+++ b/src/lib/container-provider/docker.ts
@@ -10,6 +10,7 @@ import { join } from "node:path"
 import { dirname } from "node:path"
 import { tmpdir } from "node:os"
 import { unlink } from "node:fs/promises"
+import { getAgentConfigDirs, collectContainerEnv, checkAgentAuth, type AgentAuthMethod } from "../agent-config.ts"
 import type {
   ContainerProvider,
   ContainerHandle,
@@ -28,9 +29,6 @@ export function setDockerBin(bin: string): void { _dockerBin = bin }
 
 /** Reset the docker binary to the default "docker". */
 export function resetDockerBin(): void { _dockerBin = "docker" }
-
-/** Env var keys forwarded into sandbox containers. Shared with modal.ts. */
-const CONTAINER_ENV_KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"] as const
 
 /** Read a subprocess stream to string, trimming whitespace. */
 async function readStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
@@ -288,8 +286,14 @@ export async function createDockerProvider(config: Record<string, unknown>): Pro
 
   // Collect env secrets
   const envFlags: string[] = []
-  for (const key of CONTAINER_ENV_KEYS) {
-    if (process.env[key]) envFlags.push("--env", `${key}=${process.env[key]}`)
+  for (const [key, value] of Object.entries(collectContainerEnv())) {
+    envFlags.push("--env", `${key}=${value}`)
+  }
+
+  // Bind-mount agent config dirs (Codex, OpenCode) read-only
+  const configMountFlags: string[] = []
+  for (const { hostPath, containerPath } of getAgentConfigDirs()) {
+    configMountFlags.push("-v", `${hostPath}:${containerPath}:ro`)
   }
 
   // Construct labels
@@ -302,6 +306,7 @@ export async function createDockerProvider(config: Record<string, unknown>): Pro
     "--name", name,
     ...labelFlags,
     ...envFlags,
+    ...configMountFlags,
     "autoauto-runner:latest",
     "sleep", "infinity",
   ]
@@ -324,7 +329,7 @@ export async function createDockerProvider(config: Record<string, unknown>): Pro
 /**
  * Check if Docker is available and required env vars are set.
  */
-export async function checkDockerAuth(): Promise<{ ok: boolean; error?: string }> {
+export async function checkDockerAuth(): Promise<{ ok: boolean; error?: string; authMethod?: AgentAuthMethod }> {
   try {
     const proc = Bun.spawn([_dockerBin, "info"], { stdout: "pipe", stderr: "pipe" })
     const exitCode = await Promise.race([
@@ -347,12 +352,8 @@ export async function checkDockerAuth(): Promise<{ ok: boolean; error?: string }
     }
   }
 
-  if (!process.env.ANTHROPIC_API_KEY) {
-    return {
-      ok: false,
-      error: "ANTHROPIC_API_KEY required — the experiment agent runs inside the container",
-    }
-  }
+  const agentAuth = checkAgentAuth()
+  if (!agentAuth.ok) return agentAuth
 
-  return { ok: true }
+  return { ok: true, authMethod: agentAuth.authMethod }
 }

--- a/src/lib/container-provider/modal.ts
+++ b/src/lib/container-provider/modal.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { unlink } from "node:fs/promises"
 import { ModalClient, NotFoundError } from "modal"
+import { getAgentConfigFiles, collectContainerEnv, checkAgentAuth, type AgentAuthMethod } from "../agent-config.ts"
 import type { Sandbox, Secret } from "modal"
 import type {
   ContainerProvider,
@@ -234,10 +235,7 @@ export async function createModalProvider(config: Record<string, unknown>): Prom
     ])
 
   // Collect secrets from env vars — the experiment agent needs these inside the sandbox
-  const envSecrets: Record<string, string> = {}
-  for (const key of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"]) {
-    if (process.env[key]) envSecrets[key] = process.env[key]!
-  }
+  const envSecrets = collectContainerEnv()
   const secrets: Secret[] = []
   if (Object.keys(envSecrets).length > 0) {
     secrets.push(await modal.secrets.fromObject(envSecrets))
@@ -257,7 +255,18 @@ export async function createModalProvider(config: Record<string, unknown>): Prom
     ...(name ? { name } : {}),
   })
 
-  return new ModalContainerProvider(modal, sandbox, appName)
+  const provider = new ModalContainerProvider(modal, sandbox, appName)
+
+  // Upload agent config files (Codex, OpenCode) into the sandbox
+  const configFiles = await getAgentConfigFiles()
+  await Promise.allSettled(
+    configFiles.map(async ({ localPath, remotePath }) => {
+      const data = new Uint8Array(await Bun.file(localPath).arrayBuffer())
+      await provider.writeFile(remotePath, data)
+    }),
+  )
+
+  return provider
 }
 
 /**
@@ -290,18 +299,15 @@ export async function lookupModalSandbox(
  * Check if Modal auth environment variables are set.
  * This is a static check — does not make any API calls.
  */
-export function checkModalAuth(): { ok: boolean; error?: string } {
+export function checkModalAuth(): { ok: boolean; error?: string; authMethod?: AgentAuthMethod } {
   if (!process.env.MODAL_TOKEN_ID || !process.env.MODAL_TOKEN_SECRET) {
     return {
       ok: false,
       error: "Set MODAL_TOKEN_ID and MODAL_TOKEN_SECRET environment variables (https://modal.com/settings)",
     }
   }
-  if (!process.env.ANTHROPIC_API_KEY) {
-    return {
-      ok: false,
-      error: "ANTHROPIC_API_KEY required — the experiment agent runs inside the sandbox",
-    }
-  }
-  return { ok: true }
+  const agentAuth = checkAgentAuth()
+  if (!agentAuth.ok) return agentAuth
+
+  return { ok: true, authMethod: agentAuth.authMethod }
 }

--- a/src/screens/PreRunScreen.tsx
+++ b/src/screens/PreRunScreen.tsx
@@ -97,6 +97,7 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
   const [carryForward, setCarryForward] = useState(true)
   const [sandboxChoice, setSandboxChoice] = useState<SandboxChoice>("off")
   const [sandboxAuthError, setSandboxAuthError] = useState<string | null>(null)
+  const [sandboxAuthMethod, setSandboxAuthMethod] = useState<string | null>(null)
   const [hasPreviousRuns, setHasPreviousRuns] = useState(false)
   const [pickingModel, setPickingModel] = useState(false)
   const [programConfig, setProgramConfig] = useState<ProgramConfig | null>(null)
@@ -169,36 +170,36 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
     setModelSlot(nextSlot)
   }
 
+  function applySandboxAuth(auth: { ok: boolean; error?: string; authMethod?: string }) {
+    if (!auth.ok) {
+      setSandboxAuthError(auth.error ?? "Sandbox auth failed")
+      setSandboxAuthMethod(null)
+    } else {
+      setSandboxAuthError(null)
+      setSandboxAuthMethod(auth.authMethod ?? null)
+    }
+  }
+
   function handleCycleSandbox(direction: -1 | 1) {
     const next = cycleChoice(SANDBOX_CHOICES, sandboxChoice, direction)
     setSandboxChoice(next)
 
     if (next === "off") {
       setSandboxAuthError(null)
+      setSandboxAuthMethod(null)
       return
     }
 
     if (next === DOCKER_PROVIDER_ID) {
       import("../lib/container-provider/docker.ts").then(({ checkDockerAuth }) => {
-        checkDockerAuth().then((auth) => {
-          if (!auth.ok) {
-            setSandboxAuthError(auth.error ?? "Docker auth failed")
-          } else {
-            setSandboxAuthError(null)
-          }
-        })
+        checkDockerAuth().then(applySandboxAuth)
       })
       return
     }
 
     if (next === MODAL_PROVIDER_ID) {
       import("../lib/container-provider/modal.ts").then(({ checkModalAuth }) => {
-        const auth = checkModalAuth()
-        if (!auth.ok) {
-          setSandboxAuthError(auth.error ?? "Modal auth failed")
-        } else {
-          setSandboxAuthError(null)
-        }
+        applySandboxAuth(checkModalAuth())
       })
     }
   }
@@ -349,6 +350,9 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
       <CycleField label="Sandbox" value={SANDBOX_LABELS[sandboxChoice]} description={SANDBOX_DESCRIPTIONS[sandboxChoice]} isFocused={selected === 5} />
       {sandboxAuthError && (
         <text fg={colors.error}>{`  ⚠ ${sandboxAuthError}`}</text>
+      )}
+      {useSandbox && !sandboxAuthError && sandboxAuthMethod === "oauth_token" && (
+        <text fg={colors.textMuted}>{"  Using Claude subscription auth (CLAUDE_CODE_OAUTH_TOKEN)"}</text>
       )}
       {useSandbox && (
         <text fg={colors.textMuted}>{"  Sandbox runs cannot be queued yet"}</text>

--- a/src/screens/PreRunScreen.tsx
+++ b/src/screens/PreRunScreen.tsx
@@ -147,12 +147,14 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
 
   function handleStart() {
     if (programHasQueueEntries) return
+    if (sandboxAuthError) return
     const overrides = buildOverrides()
     if (overrides) onStart(overrides)
   }
 
   function handleAddToQueue() {
     if (!onAddToQueue) return
+    if (sandboxAuthError) return
     const overrides = buildOverrides()
     if (overrides) onAddToQueue(overrides)
   }
@@ -169,9 +171,9 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
 
   function handleCycleSandbox(direction: -1 | 1) {
     const next = cycleChoice(SANDBOX_CHOICES, sandboxChoice, direction)
+    setSandboxChoice(next)
 
     if (next === "off") {
-      setSandboxChoice("off")
       setSandboxAuthError(null)
       return
     }
@@ -181,10 +183,9 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
         checkDockerAuth().then((auth) => {
           if (!auth.ok) {
             setSandboxAuthError(auth.error ?? "Docker auth failed")
-            return
+          } else {
+            setSandboxAuthError(null)
           }
-          setSandboxAuthError(null)
-          setSandboxChoice(DOCKER_PROVIDER_ID)
         })
       })
       return
@@ -195,10 +196,9 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
         const auth = checkModalAuth()
         if (!auth.ok) {
           setSandboxAuthError(auth.error ?? "Modal auth failed")
-          return
+        } else {
+          setSandboxAuthError(null)
         }
-        setSandboxAuthError(null)
-        setSandboxChoice(MODAL_PROVIDER_ID)
       })
     }
   }


### PR DESCRIPTION
## Summary

- Forward `CLAUDE_CODE_OAUTH_TOKEN` env var into sandbox containers for subscription-based auth (credentials live in macOS Keychain, not on disk — `claude setup-token` generates a 1-year token)
- Bind-mount `~/.codex` and `~/.config/opencode` into Docker containers (read-only); upload them for Modal sandboxes
- Centralize container env vars, auth checks, and config dir discovery in `src/lib/agent-config.ts` — single source of truth shared by Docker and Modal providers
- Show "Using Claude subscription auth" on PreRunScreen when `CLAUDE_CODE_OAUTH_TOKEN` is the active auth method
- Respect `CODEX_HOME` env var for custom Codex config locations

## Test plan

- [ ] `bun typecheck` passes
- [ ] `bun lint` passes (no new warnings in changed files)
- [ ] `bun test src/e2e/container-provider.e2e.test.ts` — 18/18 pass
- [ ] Verify Docker sandbox run with `ANTHROPIC_API_KEY` still works
- [ ] Verify Docker sandbox run with `CLAUDE_CODE_OAUTH_TOKEN` (no API key) works
- [ ] Verify PreRunScreen shows subscription auth hint when toggling to Docker/Modal sandbox without API key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced centralized agent configuration system for sandbox environments.
  * Added support for multiple authentication methods (API key and OAuth token).
  * Automatic mounting of configuration directories and files into sandboxes.
  * Enhanced UI to indicate active authentication method.

* **Improvements**
  * Improved environment variable management for container execution.
  * Graceful handling of configuration file discovery with size validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->