### PR TITLE
feat(sandbox): sync agent config into remote containers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -384,11 +384,11 @@ async function cmdStart(args: ParsedArgs) {
       // Validate and check auth for the chosen provider
       if (sandboxProvider === "docker") {
         const { checkDockerAuth } = await import("./lib/container-provider/docker.ts")
-        const auth = await checkDockerAuth()
+        const auth = await checkDockerAuth(modelConfig.provider)
         if (!auth.ok) die(auth.error!)
       } else if (sandboxProvider === "modal") {
         const { checkModalAuth } = await import("./lib/container-provider/modal.ts")
-        const auth = checkModalAuth()
+        const auth = await checkModalAuth(modelConfig.provider)
         if (!auth.ok) die(auth.error!)
       } else {
         die(`Unknown sandbox provider: "${sandboxProvider}". Use "docker" or "modal".`)
@@ -1762,8 +1762,9 @@ async function cmdSandbox(args: ParsedArgs) {
   try { await loadProgramConfig(programDir) }
   catch { die(`Program "${slug}" not found.`) }
 
+  const projectConfig = await loadProjectConfig(root)
   const { checkModalAuth } = await import("./lib/container-provider/modal.ts")
-  const auth = checkModalAuth()
+  const auth = await checkModalAuth(projectConfig.executionModel.provider)
   if (!auth.ok) die(auth.error!)
 
   const { getContainerProviderFactory, MODAL_PROVIDER_ID } = await import("./lib/container-provider/index.ts")

--- a/src/e2e/container-provider.e2e.test.ts
+++ b/src/e2e/container-provider.e2e.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from "bun:test"
 import { $ } from "bun"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, rm, symlink } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { MockContainerProvider } from "../lib/container-provider/mock.ts"
@@ -125,6 +125,28 @@ describe("ContainerProvider contract (MockContainerProvider)", () => {
 
     expect(new TextDecoder().decode(await provider.readFile("workspace/extras/config.local.json"))).toContain("secret")
     expect(new TextDecoder().decode(await provider.readFile("workspace/extras/nested/note.txt"))).toContain("nested note")
+  })
+
+  test("uploadRepo follows symlinked extra directories", async () => {
+    await setup()
+    const localRepo = join(rootDir, "local-repo-symlink")
+    const { mkdir: mkdirFs } = await import("node:fs/promises")
+    await mkdirFs(join(localRepo, "extras", "real-dir"), { recursive: true })
+    await $`git init`.cwd(localRepo).quiet()
+    await $`git config user.email "test@test.com"`.cwd(localRepo).quiet()
+    await $`git config user.name "Test"`.cwd(localRepo).quiet()
+    await Bun.write(join(localRepo, "tracked.txt"), "tracked")
+    await $`git add -A`.cwd(localRepo).quiet()
+    await $`git commit -m "init"`.cwd(localRepo).quiet()
+
+    await Bun.write(join(localRepo, "extras", "real-dir", "note.txt"), "through symlink\n")
+    await symlink("real-dir", join(localRepo, "extras", "link-dir"))
+
+    await provider.uploadRepo(localRepo, "workspace", {
+      extraCopyPaths: ["extras/link-dir"],
+    })
+
+    expect(new TextDecoder().decode(await provider.readFile("workspace/extras/link-dir/note.txt"))).toContain("through symlink")
   })
 
   // --- poll / terminate ---

--- a/src/e2e/container-provider.e2e.test.ts
+++ b/src/e2e/container-provider.e2e.test.ts
@@ -149,6 +149,29 @@ describe("ContainerProvider contract (MockContainerProvider)", () => {
     expect(new TextDecoder().decode(await provider.readFile("workspace/extras/link-dir/note.txt"))).toContain("through symlink")
   })
 
+  test("uploadRepo ignores broken symlink extra paths", async () => {
+    await setup()
+    const localRepo = join(rootDir, "local-repo-broken-symlink")
+    const { mkdir: mkdirFs } = await import("node:fs/promises")
+    await mkdirFs(join(localRepo, "extras"), { recursive: true })
+    await $`git init`.cwd(localRepo).quiet()
+    await $`git config user.email "test@test.com"`.cwd(localRepo).quiet()
+    await $`git config user.name "Test"`.cwd(localRepo).quiet()
+    await Bun.write(join(localRepo, "tracked.txt"), "tracked")
+    await $`git add -A`.cwd(localRepo).quiet()
+    await $`git commit -m "init"`.cwd(localRepo).quiet()
+
+    await symlink("missing-dir", join(localRepo, "extras", "broken-link"))
+
+    await expect(provider.uploadRepo(localRepo, "workspace", {
+      extraCopyPaths: ["extras/broken-link"],
+    })).resolves.toBeUndefined()
+
+    const result = await provider.exec(["git", "log", "--oneline"], { cwd: "workspace" })
+    expect(result.exitCode).toBe(0)
+    await expect(provider.readFile("workspace/extras/broken-link")).rejects.toThrow("ENOENT")
+  })
+
   // --- poll / terminate ---
 
   test("poll returns null when no main process", async () => {

--- a/src/e2e/container-provider.e2e.test.ts
+++ b/src/e2e/container-provider.e2e.test.ts
@@ -104,6 +104,29 @@ describe("ContainerProvider contract (MockContainerProvider)", () => {
     expect(logOutput).toContain("init")
   })
 
+  test("uploadRepo copies explicit extra paths after restoring the git bundle", async () => {
+    await setup()
+    const localRepo = join(rootDir, "local-repo-extra")
+    const { mkdir: mkdirFs } = await import("node:fs/promises")
+    await mkdirFs(join(localRepo, "extras", "nested"), { recursive: true })
+    await $`git init`.cwd(localRepo).quiet()
+    await $`git config user.email "test@test.com"`.cwd(localRepo).quiet()
+    await $`git config user.name "Test"`.cwd(localRepo).quiet()
+    await Bun.write(join(localRepo, "tracked.txt"), "tracked")
+    await $`git add -A`.cwd(localRepo).quiet()
+    await $`git commit -m "init"`.cwd(localRepo).quiet()
+
+    await Bun.write(join(localRepo, "extras", "config.local.json"), '{"token":"secret"}\n')
+    await Bun.write(join(localRepo, "extras", "nested", "note.txt"), "nested note\n")
+
+    await provider.uploadRepo(localRepo, "workspace", {
+      extraCopyPaths: ["extras/config.local.json", "extras/nested"],
+    })
+
+    expect(new TextDecoder().decode(await provider.readFile("workspace/extras/config.local.json"))).toContain("secret")
+    expect(new TextDecoder().decode(await provider.readFile("workspace/extras/nested/note.txt"))).toContain("nested note")
+  })
+
   // --- poll / terminate ---
 
   test("poll returns null when no main process", async () => {

--- a/src/e2e/docker-integration.e2e.test.tsx
+++ b/src/e2e/docker-integration.e2e.test.tsx
@@ -4,7 +4,7 @@
  * using the local filesystem. No real Docker daemon required.
  *
  * Covers:
- * - checkDockerAuth (daemon detection, API key validation)
+ * - checkDockerAuth (daemon detection, provider-specific auth validation)
  * - createDockerProvider (container creation, labels, env vars)
  * - exec, readFile, writeFile, uploadRepo
  * - poll / terminate lifecycle
@@ -546,6 +546,7 @@ describe("Docker E2E (mocked CLI)", () => {
     })
 
     function renderPreRun(opts?: {
+      defaultModelConfig?: PreRunOverrides["modelConfig"]
       navigate?: (s: import("../lib/programs.ts").Screen) => void
       onStart?: (o: PreRunOverrides) => void
     }) {
@@ -553,7 +554,7 @@ describe("Docker E2E (mocked CLI)", () => {
         <PreRunScreen
           cwd={fixture.cwd}
           programSlug="docker-e2e"
-          defaultModelConfig={DEFAULT_CONFIG.executionModel}
+          defaultModelConfig={opts?.defaultModelConfig ?? DEFAULT_CONFIG.executionModel}
           navigate={opts?.navigate ?? (() => {})}
           onStart={opts?.onStart ?? (() => {})}
         />,
@@ -624,6 +625,32 @@ describe("Docker E2E (mocked CLI)", () => {
       expect(startOverrides!.sandboxProvider).toBe("docker")
       // Sandbox forces worktree off
       expect(startOverrides!.useWorktree).toBe(false)
+    })
+
+    test("Codex sandbox auth does not require ANTHROPIC_API_KEY", async () => {
+      const saved = process.env.ANTHROPIC_API_KEY
+      delete process.env.ANTHROPIC_API_KEY
+
+      try {
+        let startOverrides: PreRunOverrides | null = null
+        harness = await renderPreRun({
+          defaultModelConfig: { provider: "codex", model: "default", effort: "high" },
+          onStart: (o) => { startOverrides = o },
+        })
+        await goToSandbox(harness)
+
+        await harness.press("l")
+        const frame = await harness.waitForText("local Docker container")
+        expect(frame).toContain("Docker")
+        expect(frame).not.toContain("ANTHROPIC_API_KEY")
+
+        await harness.press("s")
+        expect(startOverrides).not.toBeNull()
+        expect(startOverrides!.modelConfig.provider).toBe("codex")
+        expect(startOverrides!.useSandbox).toBe(true)
+      } finally {
+        if (saved !== undefined) process.env.ANTHROPIC_API_KEY = saved
+      }
     })
   })
 })

--- a/src/e2e/docker-integration.e2e.test.tsx
+++ b/src/e2e/docker-integration.e2e.test.tsx
@@ -14,6 +14,7 @@
 
 import { describe, test, expect, beforeAll, afterEach, afterAll } from "bun:test"
 import { mkdtemp, rm, mkdir, chmod, readdir } from "node:fs/promises"
+import { existsSync } from "node:fs"
 import { join, dirname } from "node:path"
 import { tmpdir } from "node:os"
 import { $ } from "bun"
@@ -180,6 +181,42 @@ describe("Docker E2E (mocked CLI)", () => {
       const status = (await Bun.file(join(mockDir, "containers", staleName, "status")).text()).trim()
       expect(status).toBe("running")
     })
+
+    test("builds the default image on first use", async () => {
+      await makeProvider("image-default", "run-image-default")
+
+      expect(existsSync(join(mockDir, "last-build-args"))).toBe(true)
+      const buildArgs = (await Bun.file(join(mockDir, "last-build-args")).text()).trim().split("\n")
+      expect(buildArgs[0]).toBe("-t")
+      expect(buildArgs[1]).toContain("autoauto-runner:")
+      expect(buildArgs[2]).toBe("-")
+    })
+
+    test("uses .autoauto/Dockerfile when mainRoot provides one", async () => {
+      const projectRoot = await mkdtemp(join(tmpdir(), "docker-project-"))
+      await mkdir(join(projectRoot, ".autoauto"), { recursive: true })
+      await Bun.write(
+        join(projectRoot, ".autoauto", "Dockerfile"),
+        "FROM ubuntu:22.04\nRUN echo custom > /custom.txt\n",
+      )
+
+      try {
+        await createDockerProvider({
+          programSlug: "custom-image",
+          runId: "run-custom-image",
+          mainRoot: projectRoot,
+        })
+
+        const buildArgs = (await Bun.file(join(mockDir, "last-build-args")).text()).trim().split("\n")
+        expect(buildArgs[0]).toBe("-t")
+        expect(buildArgs[1]).toContain("autoauto-runner:")
+        expect(buildArgs[2]).toBe("-f")
+        expect(buildArgs[3]).toBe(join(projectRoot, ".autoauto", "Dockerfile"))
+        expect(buildArgs[4]).toBe(projectRoot)
+      } finally {
+        await rm(projectRoot, { recursive: true, force: true })
+      }
+    })
   })
 
   // =========================================================================
@@ -267,26 +304,34 @@ describe("Docker E2E (mocked CLI)", () => {
   // uploadRepo
   // =========================================================================
   describe("uploadRepo", () => {
-    test("copies local directory into container", async () => {
+    test("restores committed repo contents into container via git bundle", async () => {
       const provider = await makeProvider("upload-test", "run-up")
 
-      // Create a temp local directory with files
-      const localDir = await mkdtemp(join(tmpdir(), "upload-src-"))
+      const localRepo = await mkdtemp(join(tmpdir(), "upload-src-"))
       try {
-        await Bun.write(join(localDir, "README.md"), "# Test Repo\n")
-        await mkdir(join(localDir, "src"), { recursive: true })
-        await Bun.write(join(localDir, "src", "index.ts"), "console.log('hello')\n")
+        await $`git init`.cwd(localRepo).quiet()
+        await $`git config user.email "test@test.com"`.cwd(localRepo).quiet()
+        await $`git config user.name "Test"`.cwd(localRepo).quiet()
+        await Bun.write(join(localRepo, "README.md"), "# Test Repo\n")
+        await mkdir(join(localRepo, "src"), { recursive: true })
+        await Bun.write(join(localRepo, "src", "index.ts"), "console.log('hello')\n")
+        await $`git add -A`.cwd(localRepo).quiet()
+        await $`git commit -m "initial commit"`.cwd(localRepo).quiet()
 
-        await provider.uploadRepo(localDir, "/workspace")
+        await Bun.write(join(localRepo, "README.md"), "# Uncommitted change\n")
+        await Bun.write(join(localRepo, "untracked.txt"), "should not upload\n")
 
-        // Verify files exist in the container
+        await provider.uploadRepo(localRepo, "/workspace")
+
         const readme = await provider.readFile("/workspace/README.md")
         expect(decoder.decode(readme)).toBe("# Test Repo\n")
 
         const index = await provider.readFile("/workspace/src/index.ts")
         expect(decoder.decode(index)).toBe("console.log('hello')\n")
+
+        await expect(provider.readFile("/workspace/untracked.txt")).rejects.toThrow("ENOENT")
       } finally {
-        await rm(localDir, { recursive: true, force: true })
+        await rm(localRepo, { recursive: true, force: true })
       }
     })
 
@@ -309,6 +354,33 @@ describe("Docker E2E (mocked CLI)", () => {
         const result = await provider.exec(["git", "log", "--oneline"], { cwd: "/workspace" })
         expect(result.exitCode).toBe(0)
         expect(decoder.decode(result.stdout)).toContain("initial commit")
+      } finally {
+        await rm(localRepo, { recursive: true, force: true })
+      }
+    })
+
+    test("copies explicit extra files and directories after the bundle restore", async () => {
+      const provider = await makeProvider("upload-extra", "run-extra")
+
+      const localRepo = await mkdtemp(join(tmpdir(), "upload-extra-src-"))
+      try {
+        await $`git init`.cwd(localRepo).quiet()
+        await $`git config user.email "test@test.com"`.cwd(localRepo).quiet()
+        await $`git config user.name "Test"`.cwd(localRepo).quiet()
+        await mkdir(join(localRepo, "extras", "nested"), { recursive: true })
+        await Bun.write(join(localRepo, "README.md"), "# Test Repo\n")
+        await $`git add -A`.cwd(localRepo).quiet()
+        await $`git commit -m "initial commit"`.cwd(localRepo).quiet()
+
+        await Bun.write(join(localRepo, "extras", "config.local.json"), '{"token":"secret"}\n')
+        await Bun.write(join(localRepo, "extras", "nested", "note.txt"), "nested note\n")
+
+        await provider.uploadRepo(localRepo, "/workspace", {
+          extraCopyPaths: ["extras/config.local.json", "extras/nested"],
+        })
+
+        expect(decoder.decode(await provider.readFile("/workspace/extras/config.local.json"))).toContain("secret")
+        expect(decoder.decode(await provider.readFile("/workspace/extras/nested/note.txt"))).toContain("nested note")
       } finally {
         await rm(localRepo, { recursive: true, force: true })
       }

--- a/src/e2e/docker-integration.e2e.test.tsx
+++ b/src/e2e/docker-integration.e2e.test.tsx
@@ -14,7 +14,6 @@
 
 import { describe, test, expect, beforeAll, afterEach, afterAll } from "bun:test"
 import { mkdtemp, rm, mkdir, chmod, readdir } from "node:fs/promises"
-import { existsSync } from "node:fs"
 import { join, dirname } from "node:path"
 import { tmpdir } from "node:os"
 import { $ } from "bun"
@@ -185,11 +184,22 @@ describe("Docker E2E (mocked CLI)", () => {
     test("builds the default image on first use", async () => {
       await makeProvider("image-default", "run-image-default")
 
-      expect(existsSync(join(mockDir, "last-build-args"))).toBe(true)
+      expect(await Bun.file(join(mockDir, "last-build-args")).exists()).toBe(true)
       const buildArgs = (await Bun.file(join(mockDir, "last-build-args")).text()).trim().split("\n")
       expect(buildArgs[0]).toBe("-t")
       expect(buildArgs[1]).toContain("autoauto-runner:")
       expect(buildArgs[2]).toBe("-")
+    })
+
+    test("mock docker image without subcommand returns a helpful usage error", async () => {
+      const proc = Bun.spawn([join(mockBinDir, "docker"), "image"], { stdout: "pipe", stderr: "pipe" })
+      const [stderr, exitCode] = await Promise.all([
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+
+      expect(exitCode).toBe(1)
+      expect(stderr).toContain("Usage: docker image <subcommand>")
     })
 
     test("uses .autoauto/Dockerfile when mainRoot provides one", async () => {
@@ -250,6 +260,17 @@ describe("Docker E2E (mocked CLI)", () => {
       const result = await provider.exec(["cat", "data.txt"], { cwd: "/mydir" })
       expect(result.exitCode).toBe(0)
       expect(decoder.decode(result.stdout).trim()).toBe("found it")
+    })
+
+    test("fails clearly when workdir cannot be entered", async () => {
+      const provider = await makeProvider("bad-wd", "run-bad-wd")
+
+      const rootfs = join(mockDir, "containers", "autoauto-bad-wd-run-bad-wd", "rootfs")
+      await Bun.write(join(rootfs, "blocked"), "not a directory")
+
+      const result = await provider.exec(["pwd"], { cwd: "/blocked" })
+      expect(result.exitCode).not.toBe(0)
+      expect(decoder.decode(result.stderr)).toContain("Failed to cd to workdir")
     })
 
     test("passes --env option", async () => {

--- a/src/e2e/first-setup-screen.e2e.test.tsx
+++ b/src/e2e/first-setup-screen.e2e.test.tsx
@@ -7,6 +7,8 @@ import type { Screen } from "../lib/programs.ts"
 import type { ProjectConfig } from "../lib/config.ts"
 import { setProvider } from "../lib/agent/index.ts"
 import { MockProvider } from "../lib/agent/mock-provider.ts"
+import type { AuthResult } from "../lib/agent/types.ts"
+import { getUserAuthConfigPath } from "../lib/user-auth.ts"
 
 let fixture: TestFixture
 let harness: TuiHarness | null = null
@@ -16,13 +18,41 @@ beforeAll(async () => {
   fixture = await createTestFixture()
 })
 
+const originalConfigHome = process.env.AUTOAUTO_CONFIG_HOME
+const originalOauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+const originalApiKey = process.env.ANTHROPIC_API_KEY
+
 afterEach(async () => {
   await harness?.destroy()
   harness = null
   resetProjectRoot()
+  if (originalConfigHome === undefined) delete process.env.AUTOAUTO_CONFIG_HOME
+  else process.env.AUTOAUTO_CONFIG_HOME = originalConfigHome
+  if (originalOauthToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+  else process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOauthToken
+  if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY
+  else process.env.ANTHROPIC_API_KEY = originalApiKey
   // Restore default mock provider in case a test replaced it
   setProvider("claude", new MockProvider())
 })
+
+class EnvClaudeProvider extends MockProvider {
+  async checkAuth(): Promise<AuthResult> {
+    return process.env.CLAUDE_CODE_OAUTH_TOKEN === "persisted-token"
+      ? { authenticated: true, account: { email: "persisted@example.com" } }
+      : { authenticated: false, error: "No Claude auth configured" }
+  }
+}
+
+async function focusContinue(harness: TuiHarness): Promise<void> {
+  await Array.from({ length: 6 }).reduce(
+    async (prev) => {
+      await prev
+      await harness.press("j")
+    },
+    Promise.resolve(),
+  )
+}
 
 afterAll(async () => {
   await fixture.cleanup()
@@ -87,7 +117,7 @@ describe("FirstSetupScreen E2E", () => {
     )
     await harness.frame()
     // Navigate to Continue button at row 6
-    for (let i = 0; i < 6; i++) await harness.press("j")
+    await focusContinue(harness)
     await harness.enter()
     await harness.waitForText("setup", 3000).catch(() => {})
     await harness.flush(300)
@@ -110,9 +140,47 @@ describe("FirstSetupScreen E2E", () => {
     )
     await harness.frame()
     // Navigate to Continue button at row 6
-    for (let i = 0; i < 6; i++) await harness.press("j")
+    await focusContinue(harness)
     await harness.enter()
     const frame = await harness.waitForText("Auth failed", 3000)
     expect(frame).toContain("Invalid API key")
+  })
+
+  test("offers permanent Claude token setup and saves it", async () => {
+    process.env.AUTOAUTO_CONFIG_HOME = `${fixture.cwd}/.test-auth`
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+    delete process.env.ANTHROPIC_API_KEY
+    setProvider("claude", new EnvClaudeProvider())
+
+    let lastNav: Screen | null = null
+    let savedConfig: ProjectConfig | null = null
+    harness = await renderTui(
+      <FirstSetupScreen
+        cwd={fixture.cwd}
+        navigate={(s) => { lastNav = s }}
+        onConfigChange={(c) => { savedConfig = c }}
+      />,
+    )
+    await harness.frame()
+    await focusContinue(harness)
+    await harness.enter()
+
+    const helpFrame = await harness.waitForText("Press t to paste it into AutoAuto", 3000)
+    expect(helpFrame).toContain("claude setup-token")
+
+    await harness.press("t")
+    await harness.waitForText("Paste CLAUDE_CODE_OAUTH_TOKEN", 3000)
+    await harness.type("persisted-token")
+    await harness.enter()
+
+    await harness.waitForText("setup", 3000).catch(() => {})
+    await harness.flush(300)
+
+    expect(lastNav).toBe("setup")
+    expect(savedConfig).not.toBeNull()
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("persisted-token")
+
+    const stored = await Bun.file(getUserAuthConfigPath()).json() as { claudeCodeOAuthToken?: string }
+    expect(stored.claudeCodeOAuthToken).toBe("persisted-token")
   })
 })

--- a/src/e2e/mock-docker.sh
+++ b/src/e2e/mock-docker.sh
@@ -56,7 +56,12 @@ info)
 # docker image inspect IMAGE — succeed only for previously built images
 # ---------------------------------------------------------------------------
 image)
-  subcmd="$1"; shift
+  subcmd="${1:-}"
+  if [ -z "$subcmd" ]; then
+    echo "Usage: docker image <subcommand>" >&2
+    exit 1
+  fi
+  shift
   if [ "$subcmd" != "inspect" ]; then
     echo "Unsupported docker image subcommand: $subcmd" >&2
     exit 1
@@ -233,7 +238,10 @@ exec)
           rewritten_args+=("$arg")
         fi
       done
-      cd "$exec_cwd"
+      if ! cd "$exec_cwd"; then
+        echo "Failed to cd to workdir: $exec_cwd" >&2
+        exit 1
+      fi
       "$cmd_name" "${rewritten_args[@]}"
       exit $?
       ;;

--- a/src/e2e/mock-docker.sh
+++ b/src/e2e/mock-docker.sh
@@ -53,17 +53,44 @@ info)
   ;;
 
 # ---------------------------------------------------------------------------
-# docker image inspect — always succeed (pretend image exists)
+# docker image inspect IMAGE — succeed only for previously built images
 # ---------------------------------------------------------------------------
 image)
-  exit 0
+  subcmd="$1"; shift
+  if [ "$subcmd" != "inspect" ]; then
+    echo "Unsupported docker image subcommand: $subcmd" >&2
+    exit 1
+  fi
+  image_ref="$1"
+  image_key=$(printf '%s' "$image_ref" | tr '/:' '__')
+  if [ -f "$DOCKER_MOCK_DIR/images/$image_key" ]; then
+    echo "$image_ref"
+    exit 0
+  fi
+  echo "Error: No such image: $image_ref" >&2
+  exit 1
   ;;
 
 # ---------------------------------------------------------------------------
-# docker build — consume stdin (Dockerfile), report success
+# docker build -t IMAGE [-f DOCKERFILE] CONTEXT | -
 # ---------------------------------------------------------------------------
 build)
-  cat >/dev/null
+  image_ref=""
+  build_args=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -t) image_ref="$2"; build_args+=("$1" "$2"); shift 2 ;;
+      -f) build_args+=("$1" "$2"); shift 2 ;;
+      *) build_args+=("$1"); shift ;;
+    esac
+  done
+  mkdir -p "$DOCKER_MOCK_DIR/images"
+  printf '%s\n' "${build_args[@]}" > "$DOCKER_MOCK_DIR/last-build-args"
+  cat >/dev/null || true
+  if [ -n "$image_ref" ]; then
+    image_key=$(printf '%s' "$image_ref" | tr '/:' '__')
+    : > "$DOCKER_MOCK_DIR/images/$image_key"
+  fi
   echo "sha256:mockimage"
   exit 0
   ;;
@@ -197,9 +224,17 @@ exec)
       exit 0
       ;;
     *)
-      # General command: run in exec_cwd
+      # General command: rewrite container-absolute paths into rootfs paths
+      rewritten_args=()
+      for arg in "$@"; do
+        if [[ "$arg" == /* ]]; then
+          rewritten_args+=("$rootfs$arg")
+        else
+          rewritten_args+=("$arg")
+        fi
+      done
       cd "$exec_cwd"
-      "$cmd_name" "$@"
+      "$cmd_name" "${rewritten_args[@]}"
       exit $?
       ;;
   esac

--- a/src/e2e/sandbox-run-backend.e2e.test.ts
+++ b/src/e2e/sandbox-run-backend.e2e.test.ts
@@ -74,6 +74,27 @@ describe("SandboxRunBackend", () => {
     expect(new TextDecoder().decode(result.stdout)).toContain("init")
   })
 
+  test("spawn copies explicit sandbox extra paths after repo upload", async () => {
+    await setup()
+    await mkdir(join(mainRoot, "extra-data", "nested"), { recursive: true })
+    await Bun.write(join(mainRoot, "extra-data", "config.local.json"), '{"secret":true}\n')
+    await Bun.write(join(mainRoot, "extra-data", "nested", "note.txt"), "hello sandbox\n")
+
+    const backend = new SandboxRunBackend(async () => provider)
+    const handle = await backend.spawn({
+      mainRoot,
+      programSlug: "test-prog",
+      modelConfig: { provider: "claude", model: "sonnet", effort: "high" },
+      maxExperiments: 5,
+      sandboxExtraCopyPaths: ["extra-data/config.local.json", "extra-data/nested"],
+    })
+
+    expect(new TextDecoder().decode(await provider.readFile("/workspace/extra-data/config.local.json"))).toContain("secret")
+    expect(new TextDecoder().decode(await provider.readFile("/workspace/extra-data/nested/note.txt"))).toContain("hello sandbox")
+
+    await handle.terminate()
+  })
+
   test("sendControl writes control.json inside container", async () => {
     await setup()
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
 
+import { applyStoredAuthToEnv } from "./lib/user-auth.ts"
+
+await applyStoredAuthToEnv()
+
 if (process.argv.length > 2) {
   const { run } = await import("./cli.ts")
   await run(process.argv.slice(2))

--- a/src/lib/agent-config.ts
+++ b/src/lib/agent-config.ts
@@ -1,0 +1,109 @@
+/**
+ * Agent configuration discovery — finds config files for Claude Code, Codex,
+ * and OpenCode on the host machine so they can be forwarded into sandbox containers.
+ *
+ * When experiments run inside Docker/Modal containers, the agent CLI (claude,
+ * codex, opencode) needs its local config for authentication and settings.
+ * This module discovers those config directories and returns them as
+ * (localPath, remotePath) pairs for the container providers to mount or upload.
+ */
+
+import { homedir } from "node:os"
+import { join, relative } from "node:path"
+import { existsSync } from "node:fs"
+import { readdir } from "node:fs/promises"
+
+/** Where agent config lives inside the container (runs as root). */
+const CONTAINER_HOME = "/root"
+
+/** Max file size to upload (skip large caches/sessions). */
+const MAX_FILE_SIZE = 1_000_000 // 1 MB
+
+/** Known agent config directories relative to $HOME. */
+const AGENT_CONFIG_DIRS = [
+  ".claude",
+  ".codex",
+  ".config/opencode",
+]
+
+export interface ConfigFileEntry {
+  /** Absolute path on the host */
+  localPath: string
+  /** Absolute path inside the container */
+  remotePath: string
+}
+
+export interface ConfigDirMount {
+  /** Absolute path on the host */
+  hostPath: string
+  /** Absolute path inside the container */
+  containerPath: string
+}
+
+/**
+ * Recursively list all regular files in a directory.
+ * Returns empty array if the directory doesn't exist or isn't readable.
+ */
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = join(dir, entry.name)
+      if (entry.isDirectory()) return listFilesRecursive(fullPath)
+      if (entry.isFile()) return [fullPath]
+      return []
+    }),
+  )
+  return nested.flat()
+}
+
+/**
+ * Returns agent config directories that exist on the host.
+ * Used by the Docker provider for bind mounts.
+ */
+export function getAgentConfigDirs(): ConfigDirMount[] {
+  const home = homedir()
+  const mounts: ConfigDirMount[] = []
+
+  for (const dir of AGENT_CONFIG_DIRS) {
+    const hostPath = join(home, dir)
+    if (existsSync(hostPath)) {
+      mounts.push({
+        hostPath,
+        containerPath: `${CONTAINER_HOME}/${dir}`,
+      })
+    }
+  }
+
+  return mounts
+}
+
+/**
+ * Discover agent config files for upload to sandbox containers.
+ * Scans ~/.claude, ~/.codex, and ~/.config/opencode.
+ * Skips files larger than 1 MB to avoid uploading caches.
+ */
+export async function getAgentConfigFiles(): Promise<ConfigFileEntry[]> {
+  const home = homedir()
+
+  const nested = await Promise.all(
+    AGENT_CONFIG_DIRS.map(async (configDir) => {
+      const hostDir = join(home, configDir)
+      const files = await listFilesRecursive(hostDir)
+
+      return files
+        .filter((localPath) => Bun.file(localPath).size <= MAX_FILE_SIZE)
+        .map((localPath) => ({
+          localPath,
+          remotePath: `${CONTAINER_HOME}/${configDir}/${relative(hostDir, localPath)}`,
+        }))
+    }),
+  )
+
+  return nested.flat()
+}

--- a/src/lib/agent-config.ts
+++ b/src/lib/agent-config.ts
@@ -11,6 +11,8 @@ import { join, relative } from "node:path"
 import { homedir } from "node:os"
 import { existsSync } from "node:fs"
 import { lstat, readdir } from "node:fs/promises"
+import { checkAuth } from "./auth.ts"
+import type { AgentProviderID } from "./agent/types.ts"
 
 /** Where agent config lives inside the container (runs as root). */
 const CONTAINER_HOME = "/root"
@@ -46,9 +48,10 @@ const CONTAINER_ENV_KEYS = [
 export type AgentAuthMethod = "api_key" | "oauth_token"
 
 /**
- * Check whether agent auth credentials are available for sandbox runs.
+ * Claude sandbox auth must be env-backed because subscription tokens live in
+ * macOS Keychain on the host and are not portable via config files alone.
  */
-export function checkAgentAuth(): { ok: true; authMethod: AgentAuthMethod } | { ok: false; error: string } {
+function checkClaudeSandboxAuth(): { ok: true; authMethod: AgentAuthMethod } | { ok: false; error: string } {
   if (process.env.ANTHROPIC_API_KEY) return { ok: true, authMethod: "api_key" }
   if (process.env.CLAUDE_CODE_OAUTH_TOKEN) return { ok: true, authMethod: "oauth_token" }
 
@@ -56,6 +59,24 @@ export function checkAgentAuth(): { ok: true; authMethod: AgentAuthMethod } | { 
     ok: false,
     error: "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN required — the experiment agent runs inside the container. Run `claude setup-token` to generate a subscription token.",
   }
+}
+
+/**
+ * Check whether the selected agent provider has portable auth for sandbox runs.
+ * Claude requires env forwarding; Codex/OpenCode auth is carried via mounted
+ * config dirs, so host-side provider auth is sufficient.
+ */
+export async function checkSandboxAgentAuth(
+  provider: AgentProviderID,
+): Promise<{ ok: true; authMethod?: AgentAuthMethod } | { ok: false; error: string }> {
+  if (provider === "claude") return checkClaudeSandboxAuth()
+
+  const auth = await checkAuth(provider)
+  if (!auth.authenticated) {
+    return { ok: false, error: auth.error }
+  }
+
+  return { ok: true }
 }
 
 /**

--- a/src/lib/agent-config.ts
+++ b/src/lib/agent-config.ts
@@ -10,7 +10,7 @@
 import { join, relative } from "node:path"
 import { homedir } from "node:os"
 import { existsSync } from "node:fs"
-import { readdir } from "node:fs/promises"
+import { lstat, readdir } from "node:fs/promises"
 
 /** Where agent config lives inside the container (runs as root). */
 const CONTAINER_HOME = "/root"
@@ -123,6 +123,16 @@ export function getAgentConfigDirs(): ConfigDirMount[] {
     }))
 }
 
+async function getRegularFileSize(localPath: string): Promise<number | null> {
+  try {
+    const stats = await lstat(localPath)
+    if (!stats.isFile()) return null
+    return stats.size
+  } catch {
+    return null
+  }
+}
+
 /**
  * Discover agent config files for upload to sandbox containers.
  * Skips files larger than 1 MB to avoid uploading caches.
@@ -133,13 +143,18 @@ export async function getAgentConfigFiles(): Promise<ConfigFileEntry[]> {
   const nested = await Promise.all(
     dirs.map(async ({ hostPath, containerName }) => {
       const files = await listFilesRecursive(hostPath)
+      const entries = await Promise.all(
+        files.map(async (localPath) => {
+          const size = await getRegularFileSize(localPath)
+          if (size === null || size > MAX_FILE_SIZE) return null
+          return {
+            localPath,
+            remotePath: `${CONTAINER_HOME}/${containerName}/${relative(hostPath, localPath)}`,
+          }
+        }),
+      )
 
-      return files
-        .filter((localPath) => Bun.file(localPath).size <= MAX_FILE_SIZE)
-        .map((localPath) => ({
-          localPath,
-          remotePath: `${CONTAINER_HOME}/${containerName}/${relative(hostPath, localPath)}`,
-        }))
+      return entries.filter((entry): entry is ConfigFileEntry => entry !== null)
     }),
   )
 

--- a/src/lib/container-provider/docker.ts
+++ b/src/lib/container-provider/docker.ts
@@ -10,7 +10,7 @@ import { dirname, join } from "node:path"
 import { tmpdir } from "node:os"
 import { createHash } from "node:crypto"
 import { stat, unlink } from "node:fs/promises"
-import { collectContainerEnv, checkAgentAuth, getAgentConfigDirs, type AgentAuthMethod } from "../agent-config.ts"
+import { collectContainerEnv, checkSandboxAgentAuth, getAgentConfigDirs, type AgentAuthMethod } from "../agent-config.ts"
 import { uploadRepoViaGitBundle } from "./sync.ts"
 import type {
   ContainerProvider,
@@ -20,6 +20,7 @@ import type {
   StreamingProcess,
   UploadRepoOptions,
 } from "./types.ts"
+import type { AgentProviderID } from "../agent/types.ts"
 
 const decoder = new TextDecoder()
 
@@ -386,9 +387,12 @@ export async function createDockerProvider(config: Record<string, unknown>): Pro
 }
 
 /**
- * Check if Docker is available and required env vars are set.
+ * Check if Docker is available and the selected agent provider can authenticate
+ * inside the sandbox.
  */
-export async function checkDockerAuth(): Promise<{ ok: boolean; error?: string; authMethod?: AgentAuthMethod }> {
+export async function checkDockerAuth(
+  provider: AgentProviderID = "claude",
+): Promise<{ ok: boolean; error?: string; authMethod?: AgentAuthMethod }> {
   try {
     const proc = Bun.spawn([_dockerBin, "info"], { stdout: "pipe", stderr: "pipe" })
     const exitCode = await Promise.race([
@@ -411,7 +415,7 @@ export async function checkDockerAuth(): Promise<{ ok: boolean; error?: string; 
     }
   }
 
-  const agentAuth = checkAgentAuth()
+  const agentAuth = await checkSandboxAgentAuth(provider)
   if (!agentAuth.ok) return agentAuth
 
   return { ok: true, authMethod: agentAuth.authMethod }

--- a/src/lib/container-provider/docker.ts
+++ b/src/lib/container-provider/docker.ts
@@ -9,7 +9,7 @@
 import { dirname, join } from "node:path"
 import { tmpdir } from "node:os"
 import { createHash } from "node:crypto"
-import { lstat, unlink } from "node:fs/promises"
+import { stat, unlink } from "node:fs/promises"
 import { collectContainerEnv, checkAgentAuth, getAgentConfigDirs, type AgentAuthMethod } from "../agent-config.ts"
 import { uploadRepoViaGitBundle } from "./sync.ts"
 import type {
@@ -141,7 +141,7 @@ export class DockerContainerProvider implements ContainerProvider {
   }
 
   async copyIn(localPath: string, remotePath: string): Promise<void> {
-    const info = await lstat(localPath)
+    const info = await stat(localPath)
     if (info.isDirectory()) {
       await this.exec(["mkdir", "-p", remotePath])
       const source = `${localPath.replace(/\/+$/, "")}/.`
@@ -299,8 +299,20 @@ async function ensureImage(mainRoot?: string): Promise<string> {
     if (!stdin) {
       throw new Error(`Failed to stream default Dockerfile for image ${imageTag}`)
     }
-    stdin.write(DEFAULT_DOCKERFILE)
-    stdin.end()
+    try {
+      stdin.write(DEFAULT_DOCKERFILE)
+      stdin.end()
+    } catch (error) {
+      try {
+        stdin.end()
+      } catch {}
+      build.kill()
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(
+        `Failed to stream default Dockerfile for image ${imageTag}: ${message}`,
+        { cause: error },
+      )
+    }
   }
 
   const [stderrText, exitCode] = await Promise.all([

--- a/src/lib/container-provider/docker.ts
+++ b/src/lib/container-provider/docker.ts
@@ -2,20 +2,23 @@
  * DockerContainerProvider — uses the Docker CLI to implement ContainerProvider.
  *
  * Runs containers locally via `docker run`, executes commands via `docker exec`,
- * and transfers files via `docker cp`. Zero npm dependencies — all ops go through
- * the `docker` CLI via Bun.spawn.
+ * writes individual files via `docker cp`, and uploads repos via git bundles.
+ * Zero npm dependencies — all ops go through the `docker` CLI via Bun.spawn.
  */
 
-import { join } from "node:path"
-import { dirname } from "node:path"
+import { join, dirname } from "node:path"
 import { tmpdir } from "node:os"
-import { unlink } from "node:fs/promises"
+import { lstat, unlink } from "node:fs/promises"
+import { createHash } from "node:crypto"
+import { getAgentConfigDirs } from "../agent-config.ts"
+import { uploadRepoViaGitBundle } from "./sync.ts"
 import type {
   ContainerProvider,
   ContainerHandle,
   ExecOptions,
   ExecResult,
   StreamingProcess,
+  UploadRepoOptions,
 } from "./types.ts"
 
 const decoder = new TextDecoder()
@@ -30,7 +33,12 @@ export function setDockerBin(bin: string): void { _dockerBin = bin }
 export function resetDockerBin(): void { _dockerBin = "docker" }
 
 /** Env var keys forwarded into sandbox containers. Shared with modal.ts. */
-const CONTAINER_ENV_KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"] as const
+const CONTAINER_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "CLAUDE_CODE_OAUTH_TOKEN",  // subscription auth (from `claude setup-token`)
+] as const
 
 /** Read a subprocess stream to string, trimming whitespace. */
 async function readStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
@@ -45,6 +53,20 @@ export class DockerContainerProvider implements ContainerProvider {
   constructor(containerId: string, containerName: string) {
     this.containerId = containerId
     this.containerName = containerName
+  }
+
+  private async copyFileToContainer(localPath: string, remotePath: string, context: string): Promise<void> {
+    const proc = Bun.spawn([_dockerBin, "cp", localPath, `${this.containerId}:${remotePath}`], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stderrText, exitCode] = await Promise.all([
+      readStream(proc.stderr),
+      proc.exited,
+    ])
+    if (exitCode !== 0) {
+      throw new Error(`${context}: ${stderrText}`)
+    }
   }
 
   private buildExecArgs(command: string[], opts?: ExecOptions): string[] {
@@ -120,37 +142,30 @@ export class DockerContainerProvider implements ContainerProvider {
     const tmpFile = join(tmpdir(), `autoauto-docker-write-${Date.now()}-${Math.random().toString(36).slice(2)}`)
     try {
       await Bun.write(tmpFile, data)
-      const proc = Bun.spawn([_dockerBin, "cp", tmpFile, `${this.containerId}:${remotePath}`], {
-        stdout: "pipe",
-        stderr: "pipe",
-      })
-      // Read stderr before awaiting exit to avoid stream-closed race
-      const [stderrText, exitCode] = await Promise.all([
-        readStream(proc.stderr),
-        proc.exited,
-      ])
-      if (exitCode !== 0) {
-        throw new Error(`docker cp write failed: ${stderrText}`)
-      }
+      await this.copyFileToContainer(tmpFile, remotePath, "docker cp write failed")
     } finally {
       await unlink(tmpFile).catch(() => {})
     }
   }
 
-  async uploadRepo(localDir: string, remoteDir: string): Promise<void> {
-    await this.exec(["mkdir", "-p", remoteDir])
-
-    const proc = Bun.spawn(
-      [_dockerBin, "cp", `${localDir}/.`, `${this.containerId}:${remoteDir}`],
-      { stdout: "pipe", stderr: "pipe" },
-    )
-    const [stderrText, exitCode] = await Promise.all([
-      readStream(proc.stderr),
-      proc.exited,
-    ])
-    if (exitCode !== 0) {
-      throw new Error(`docker cp upload failed: ${stderrText}`)
+  async copyIn(localPath: string, remotePath: string): Promise<void> {
+    const info = await lstat(localPath)
+    if (info.isDirectory()) {
+      await this.exec(["mkdir", "-p", remotePath])
+      const source = `${localPath.replace(/\/+$/, "")}/.`
+      await this.copyFileToContainer(source, remotePath, "docker cp directory copy failed")
+      return
     }
+
+    const dir = dirname(remotePath)
+    if (dir !== "/" && dir !== ".") {
+      await this.exec(["mkdir", "-p", dir])
+    }
+    await this.copyFileToContainer(localPath, remotePath, "docker cp file copy failed")
+  }
+
+  async uploadRepo(localDir: string, remoteDir: string, options?: UploadRepoOptions): Promise<void> {
+    await uploadRepoViaGitBundle(this, localDir, remoteDir, options)
   }
 
   async poll(): Promise<number | null> {
@@ -237,34 +252,74 @@ export async function lookupDockerContainer(
   }
 }
 
-const DOCKERFILE = `FROM ubuntu:22.04
+const DEFAULT_DOCKERFILE = `FROM ubuntu:22.04
 RUN apt-get update -qq && apt-get install -y -qq git curl
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH=/root/.bun/bin:$PATH
 WORKDIR /workspace
 `
 
-/** Ensure the autoauto-runner Docker image exists, building it if needed. */
-async function ensureImage(): Promise<void> {
+function hashTag(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16)
+}
+
+async function resolveImage(mainRoot?: string): Promise<{ imageTag: string; dockerfilePath?: string }> {
+  if (!mainRoot) {
+    return { imageTag: `autoauto-runner:${hashTag(DEFAULT_DOCKERFILE)}` }
+  }
+
+  const dockerfilePath = join(mainRoot, ".autoauto", "Dockerfile")
+  if (!await Bun.file(dockerfilePath).exists()) {
+    return { imageTag: `autoauto-runner:${hashTag(DEFAULT_DOCKERFILE)}` }
+  }
+
+  const dockerfile = await Bun.file(dockerfilePath).text()
+  const projectHash = hashTag(mainRoot)
+  const dockerfileHash = hashTag(dockerfile)
+  return {
+    imageTag: `autoauto-runner:${projectHash}-${dockerfileHash}`,
+    dockerfilePath,
+  }
+}
+
+/** Ensure the Docker image exists, building it if needed. */
+async function ensureImage(mainRoot?: string): Promise<string> {
+  const { imageTag, dockerfilePath } = await resolveImage(mainRoot)
+
   const check = Bun.spawn(
-    [_dockerBin, "image", "inspect", "autoauto-runner:latest"],
+    [_dockerBin, "image", "inspect", imageTag],
     { stdout: "pipe", stderr: "pipe" },
   )
-  if ((await check.exited) === 0) return
+  if ((await check.exited) === 0) return imageTag
 
-  const build = Bun.spawn(
-    [_dockerBin, "build", "-t", "autoauto-runner:latest", "-"],
-    { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
-  )
-  build.stdin.write(DOCKERFILE)
-  build.stdin.end()
+  const build = dockerfilePath
+    ? Bun.spawn(
+      [_dockerBin, "build", "-t", imageTag, "-f", dockerfilePath, mainRoot!],
+      { stdout: "pipe", stderr: "pipe" },
+    )
+    : Bun.spawn(
+      [_dockerBin, "build", "-t", imageTag, "-"],
+      { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
+    )
+
+  if (!dockerfilePath) {
+    const stdin = build.stdin
+    if (!stdin) {
+      throw new Error(`Failed to stream default Dockerfile for image ${imageTag}`)
+    }
+    stdin.write(DEFAULT_DOCKERFILE)
+    stdin.end()
+  }
+
   const [stderrText, exitCode] = await Promise.all([
     readStream(build.stderr),
     build.exited,
   ])
   if (exitCode !== 0) {
-    throw new Error(`Failed to build autoauto-runner image: ${stderrText}`)
+    throw new Error(`Failed to build Docker image ${imageTag}: ${stderrText}`)
   }
+
+  return imageTag
 }
 
 /**
@@ -274,7 +329,8 @@ async function ensureImage(): Promise<void> {
  * - programSlug, runId: used to construct container name and labels
  */
 export async function createDockerProvider(config: Record<string, unknown>): Promise<DockerContainerProvider> {
-  await ensureImage()
+  const mainRoot = config.mainRoot as string | undefined
+  const imageTag = await ensureImage(mainRoot)
 
   const slug = config.programSlug as string | undefined
   const runId = config.runId as string | undefined
@@ -292,6 +348,12 @@ export async function createDockerProvider(config: Record<string, unknown>): Pro
     if (process.env[key]) envFlags.push("--env", `${key}=${process.env[key]}`)
   }
 
+  // Bind-mount agent config dirs (Claude, Codex, OpenCode) read-only
+  const configMountFlags: string[] = []
+  for (const { hostPath, containerPath } of getAgentConfigDirs()) {
+    configMountFlags.push("-v", `${hostPath}:${containerPath}:ro`)
+  }
+
   // Construct labels
   const labelFlags = ["--label", "autoauto=true"]
   if (slug) labelFlags.push("--label", `program_slug=${slug}`)
@@ -302,7 +364,8 @@ export async function createDockerProvider(config: Record<string, unknown>): Pro
     "--name", name,
     ...labelFlags,
     ...envFlags,
-    "autoauto-runner:latest",
+    ...configMountFlags,
+    imageTag,
     "sleep", "infinity",
   ]
 

--- a/src/lib/container-provider/index.ts
+++ b/src/lib/container-provider/index.ts
@@ -8,6 +8,7 @@ export type {
   ExecOptions,
   ExecResult,
   StreamingProcess,
+  UploadRepoOptions,
 } from "./types.ts"
 
 export { MockContainerProvider } from "./mock.ts"

--- a/src/lib/container-provider/mock.ts
+++ b/src/lib/container-provider/mock.ts
@@ -7,7 +7,7 @@
  */
 
 import { join, dirname } from "node:path"
-import { chmod, lstat, mkdir, readdir } from "node:fs/promises"
+import { chmod, lstat, mkdir, readdir, stat } from "node:fs/promises"
 import type {
   ContainerProvider,
   ContainerHandle,
@@ -103,7 +103,7 @@ export class MockContainerProvider implements ContainerProvider {
 
   async copyIn(localPath: string, remotePath: string): Promise<void> {
     const fullPath = join(this.rootDir, remotePath)
-    const info = await lstat(localPath)
+    const info = await stat(localPath)
 
     if (info.isDirectory()) {
       await mkdir(fullPath, { recursive: true })

--- a/src/lib/container-provider/mock.ts
+++ b/src/lib/container-provider/mock.ts
@@ -7,13 +7,14 @@
  */
 
 import { join, dirname } from "node:path"
-import { mkdir } from "node:fs/promises"
+import { chmod, lstat, mkdir, readdir } from "node:fs/promises"
 import type {
   ContainerProvider,
   ContainerHandle,
   ExecOptions,
   ExecResult,
   StreamingProcess,
+  UploadRepoOptions,
 } from "./types.ts"
 import { bundleCreate, bundleUnbundle } from "../git.ts"
 
@@ -41,8 +42,9 @@ export class MockContainerProvider implements ContainerProvider {
 
   async exec(command: string[], opts?: ExecOptions): Promise<ExecResult> {
     const cwd = opts?.cwd ? join(this.rootDir, opts.cwd) : this.rootDir
-    const env = opts?.env ? { ...process.env, ...opts.env } : undefined
-    const proc = Bun.spawn(command, {
+    const env = { ...process.env, ...opts?.env }
+    const [bin, ...args] = command
+    const proc = Bun.spawn([Bun.which(bin) ?? bin, ...args], {
       cwd,
       env,
       stdout: "pipe",
@@ -62,8 +64,9 @@ export class MockContainerProvider implements ContainerProvider {
 
   async execStreaming(command: string[], opts?: ExecOptions): Promise<StreamingProcess> {
     const cwd = opts?.cwd ? join(this.rootDir, opts.cwd) : this.rootDir
-    const env = opts?.env ? { ...process.env, ...opts.env } : undefined
-    const proc = Bun.spawn(command, {
+    const env = { ...process.env, ...opts?.env }
+    const [bin, ...args] = command
+    const proc = Bun.spawn([Bun.which(bin) ?? bin, ...args], {
       cwd,
       env,
       stdout: "pipe",
@@ -98,18 +101,47 @@ export class MockContainerProvider implements ContainerProvider {
     await Bun.write(fullPath, data)
   }
 
-  async uploadRepo(localDir: string, remoteDir: string): Promise<void> {
+  async copyIn(localPath: string, remotePath: string): Promise<void> {
+    const fullPath = join(this.rootDir, remotePath)
+    const info = await lstat(localPath)
+
+    if (info.isDirectory()) {
+      await mkdir(fullPath, { recursive: true })
+      const entries = await readdir(localPath, { withFileTypes: true })
+      await Promise.all(entries.map((entry) =>
+        this.copyIn(join(localPath, entry.name), join(remotePath, entry.name))
+      ))
+      return
+    }
+
+    const dir = dirname(fullPath)
+    await mkdir(dir, { recursive: true })
+    await Bun.write(fullPath, Bun.file(localPath))
+    await chmod(fullPath, info.mode & 0o777)
+  }
+
+  async uploadRepo(localDir: string, remoteDir: string, options?: UploadRepoOptions): Promise<void> {
     const absoluteRemoteDir = join(this.rootDir, remoteDir)
     await mkdir(absoluteRemoteDir, { recursive: true })
 
-    // Use git bundle to transfer the repo
     const bundlePath = join(this.rootDir, ".tmp-upload.bundle")
-    await bundleCreate(localDir, bundlePath)
-    await bundleUnbundle(absoluteRemoteDir, bundlePath)
+    try {
+      await bundleCreate(localDir, bundlePath)
+      await bundleUnbundle(absoluteRemoteDir, bundlePath)
 
-    // Clean up bundle
-    const { unlink } = await import("node:fs/promises")
-    await unlink(bundlePath).catch(() => {})
+      await Promise.all((options?.extraCopyPaths ?? []).map(async (relativePath) => {
+        const hostPath = join(localDir, relativePath)
+        try {
+          await lstat(hostPath)
+        } catch {
+          return
+        }
+        await this.copyIn(hostPath, join(remoteDir, relativePath))
+      }))
+    } finally {
+      const { unlink } = await import("node:fs/promises")
+      await unlink(bundlePath).catch(() => {})
+    }
   }
 
   async poll(): Promise<number | null> {

--- a/src/lib/container-provider/mock.ts
+++ b/src/lib/container-provider/mock.ts
@@ -7,7 +7,7 @@
  */
 
 import { join, dirname } from "node:path"
-import { chmod, lstat, mkdir, readdir, stat } from "node:fs/promises"
+import { chmod, mkdir, readdir, stat, unlink } from "node:fs/promises"
 import type {
   ContainerProvider,
   ContainerHandle,
@@ -132,14 +132,13 @@ export class MockContainerProvider implements ContainerProvider {
       await Promise.all((options?.extraCopyPaths ?? []).map(async (relativePath) => {
         const hostPath = join(localDir, relativePath)
         try {
-          await lstat(hostPath)
+          await stat(hostPath)
         } catch {
           return
         }
         await this.copyIn(hostPath, join(remoteDir, relativePath))
       }))
     } finally {
-      const { unlink } = await import("node:fs/promises")
       await unlink(bundlePath).catch(() => {})
     }
   }

--- a/src/lib/container-provider/mock.ts
+++ b/src/lib/container-provider/mock.ts
@@ -102,15 +102,35 @@ export class MockContainerProvider implements ContainerProvider {
   }
 
   async copyIn(localPath: string, remotePath: string): Promise<void> {
+    await this.copyInRecursive(localPath, remotePath, new Set())
+  }
+
+  private async copyInRecursive(
+    localPath: string,
+    remotePath: string,
+    visitedDirs: Set<string>,
+  ): Promise<void> {
     const fullPath = join(this.rootDir, remotePath)
     const info = await stat(localPath)
 
     if (info.isDirectory()) {
-      await mkdir(fullPath, { recursive: true })
-      const entries = await readdir(localPath, { withFileTypes: true })
-      await Promise.all(entries.map((entry) =>
-        this.copyIn(join(localPath, entry.name), join(remotePath, entry.name))
-      ))
+      const dirKey = `${info.dev}:${info.ino}`
+      if (visitedDirs.has(dirKey)) return
+      visitedDirs.add(dirKey)
+
+      try {
+        await mkdir(fullPath, { recursive: true })
+        const entries = await readdir(localPath, { withFileTypes: true })
+        for (const entry of entries) {
+          await this.copyInRecursive(
+            join(localPath, entry.name),
+            join(remotePath, entry.name),
+            visitedDirs,
+          )
+        }
+      } finally {
+        visitedDirs.delete(dirKey)
+      }
       return
     }
 

--- a/src/lib/container-provider/modal.ts
+++ b/src/lib/container-provider/modal.ts
@@ -132,18 +132,25 @@ export class ModalContainerProvider implements ContainerProvider {
     const info = await Bun.file(localPath).stat()
 
     if (info.isDirectory()) {
+      // Ancestor-stack cycle guard: only tracks the active recursion chain so
+      // non-cyclic symlink aliases (e.g. dir/link -> ../dir/real) still get
+      // materialized while true cycles are detected and skipped.
       const dirKey = `${info.dev}:${info.ino}`
       if (visitedDirs.has(dirKey)) return
       visitedDirs.add(dirKey)
 
-      await this.sandbox.exec(["mkdir", "-p", remotePath], { stdout: "ignore", stderr: "ignore" })
-      const entries = await readdir(localPath, { withFileTypes: true })
-      for (const entry of entries) {
-        await this.copyInRecursive(
-          join(localPath, entry.name),
-          posix.join(remotePath, entry.name),
-          visitedDirs,
-        )
+      try {
+        await this.sandbox.exec(["mkdir", "-p", remotePath], { stdout: "ignore", stderr: "ignore" })
+        const entries = await readdir(localPath, { withFileTypes: true })
+        for (const entry of entries) {
+          await this.copyInRecursive(
+            join(localPath, entry.name),
+            posix.join(remotePath, entry.name),
+            visitedDirs,
+          )
+        }
+      } finally {
+        visitedDirs.delete(dirKey)
       }
       return
     }

--- a/src/lib/container-provider/modal.ts
+++ b/src/lib/container-provider/modal.ts
@@ -133,7 +133,24 @@ export class ModalContainerProvider implements ContainerProvider {
 
     const bytes = new Uint8Array(await Bun.file(localPath).arrayBuffer())
     await this.writeFile(remotePath, bytes)
-    await this.sandbox.exec(["chmod", (info.mode & 0o777).toString(8), remotePath], { stdout: "ignore", stderr: "ignore" })
+
+    const mode = (info.mode & 0o777).toString(8)
+    const chmod = await this.sandbox.exec(["chmod", mode, remotePath], {
+      stdout: "ignore",
+      stderr: "pipe",
+    })
+    const [stderrText, exitCode] = await Promise.all([
+      chmod.stderr.readText(),
+      chmod.wait(),
+    ])
+    if (exitCode !== 0) {
+      const stderr = stderrText.trim()
+      throw new Error(
+        stderr
+          ? `Failed to chmod ${remotePath} to ${mode} in Modal sandbox: ${stderr}`
+          : `Failed to chmod ${remotePath} to ${mode} in Modal sandbox (exit ${exitCode})`,
+      )
+    }
   }
 
   async uploadRepo(localDir: string, remoteDir: string, options?: UploadRepoOptions): Promise<void> {

--- a/src/lib/container-provider/modal.ts
+++ b/src/lib/container-provider/modal.ts
@@ -6,7 +6,7 @@
  */
 
 import { dirname, join, posix } from "node:path"
-import { lstat, readdir } from "node:fs/promises"
+import { readdir, stat } from "node:fs/promises"
 import { ModalClient, NotFoundError } from "modal"
 import { collectContainerEnv, checkAgentAuth, getAgentConfigFiles, type AgentAuthMethod } from "../agent-config.ts"
 import type { Sandbox, Secret } from "modal"
@@ -120,7 +120,7 @@ export class ModalContainerProvider implements ContainerProvider {
   }
 
   async copyIn(localPath: string, remotePath: string): Promise<void> {
-    const info = await lstat(localPath)
+    const info = await stat(localPath)
 
     if (info.isDirectory()) {
       await this.sandbox.exec(["mkdir", "-p", remotePath], { stdout: "ignore", stderr: "ignore" })
@@ -236,12 +236,20 @@ export async function createModalProvider(config: Record<string, unknown>): Prom
 
   // Upload agent config files (Claude, Codex, OpenCode) into the sandbox
   const configFiles = await getAgentConfigFiles()
-  await Promise.allSettled(
+  const uploadResults = await Promise.allSettled(
     configFiles.map(async ({ localPath, remotePath }) => {
       const data = new Uint8Array(await Bun.file(localPath).arrayBuffer())
       await provider.writeFile(remotePath, data)
     }),
   )
+  uploadResults.forEach((result, index) => {
+    if (result.status === "fulfilled") return
+    const { localPath, remotePath } = configFiles[index]!
+    const reason = result.reason instanceof Error ? result.reason.message : String(result.reason)
+    process.stderr.write(
+      `[modal] Failed to upload agent config via provider.writeFile: ${localPath} -> ${remotePath}: ${reason}\n`,
+    )
+  })
 
   return provider
 }

--- a/src/lib/container-provider/modal.ts
+++ b/src/lib/container-provider/modal.ts
@@ -5,11 +5,10 @@
  * MODAL_TOKEN_ID and MODAL_TOKEN_SECRET environment variables.
  */
 
-import { dirname } from "node:path"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { unlink } from "node:fs/promises"
+import { dirname, join, posix } from "node:path"
+import { lstat, readdir } from "node:fs/promises"
 import { ModalClient, NotFoundError } from "modal"
+import { getAgentConfigFiles } from "../agent-config.ts"
 import type { Sandbox, Secret } from "modal"
 import type {
   ContainerProvider,
@@ -17,8 +16,9 @@ import type {
   ExecOptions,
   ExecResult,
   StreamingProcess,
+  UploadRepoOptions,
 } from "./types.ts"
-import { bundleCreate } from "../git.ts"
+import { uploadRepoViaGitBundle } from "./sync.ts"
 
 export interface ModalProviderConfig {
   /** CPU cores for the sandbox (default: 2) */
@@ -119,47 +119,25 @@ export class ModalContainerProvider implements ContainerProvider {
     }
   }
 
-  async uploadRepo(localDir: string, remoteDir: string): Promise<void> {
-    // 1. Create git bundle locally
-    const bundleFileName = `autoauto-upload-${Date.now()}.bundle`
-    const localBundlePath = join(tmpdir(), bundleFileName)
-    const remoteBundlePath = `/tmp/${bundleFileName}`
+  async copyIn(localPath: string, remotePath: string): Promise<void> {
+    const info = await lstat(localPath)
 
-    try {
-      await bundleCreate(localDir, localBundlePath)
-
-      // 2. Upload bundle bytes to container
-      const bundleBytes = new Uint8Array(await Bun.file(localBundlePath).arrayBuffer())
-
-      await this.sandbox.exec(["mkdir", "-p", remoteDir], { stdout: "ignore", stderr: "ignore" })
-
-      const handle = await this.sandbox.open(remoteBundlePath, "w")
-      await handle.write(bundleBytes)
-      await handle.close()
-
-      // 3. Clone from bundle inside the container
-      const result = await this.sandbox.exec(
-        ["git", "clone", remoteBundlePath, remoteDir],
-        { stdout: "pipe", stderr: "pipe" },
-      )
-
-      if (await result.wait() !== 0) {
-        // Fallback: init + unbundle for repos with unusual ref layouts
-        const fallback = await this.sandbox.exec(
-          ["sh", "-c", `rm -rf ${remoteDir}/.git && cd ${remoteDir} && git init && git bundle unbundle ${remoteBundlePath} && git checkout HEAD`],
-          { stdout: "pipe", stderr: "pipe" },
-        )
-        if (await fallback.wait() !== 0) {
-          throw new Error("Failed to restore repository from git bundle")
-        }
-      }
-
-      // 4. Clean up remote bundle
-      await this.sandbox.exec(["rm", "-f", remoteBundlePath], { stdout: "ignore", stderr: "ignore" })
-    } finally {
-      // Clean up local bundle
-      await unlink(localBundlePath).catch(() => {})
+    if (info.isDirectory()) {
+      await this.sandbox.exec(["mkdir", "-p", remotePath], { stdout: "ignore", stderr: "ignore" })
+      const entries = await readdir(localPath, { withFileTypes: true })
+      await Promise.all(entries.map((entry) =>
+        this.copyIn(join(localPath, entry.name), posix.join(remotePath, entry.name))
+      ))
+      return
     }
+
+    const bytes = new Uint8Array(await Bun.file(localPath).arrayBuffer())
+    await this.writeFile(remotePath, bytes)
+    await this.sandbox.exec(["chmod", (info.mode & 0o777).toString(8), remotePath], { stdout: "ignore", stderr: "ignore" })
+  }
+
+  async uploadRepo(localDir: string, remoteDir: string, options?: UploadRepoOptions): Promise<void> {
+    await uploadRepoViaGitBundle(this, localDir, remoteDir, options)
   }
 
   async poll(): Promise<number | null> {
@@ -235,7 +213,7 @@ export async function createModalProvider(config: Record<string, unknown>): Prom
 
   // Collect secrets from env vars — the experiment agent needs these inside the sandbox
   const envSecrets: Record<string, string> = {}
-  for (const key of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"]) {
+  for (const key of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL", "CLAUDE_CODE_OAUTH_TOKEN"]) {
     if (process.env[key]) envSecrets[key] = process.env[key]!
   }
   const secrets: Secret[] = []
@@ -257,7 +235,18 @@ export async function createModalProvider(config: Record<string, unknown>): Prom
     ...(name ? { name } : {}),
   })
 
-  return new ModalContainerProvider(modal, sandbox, appName)
+  const provider = new ModalContainerProvider(modal, sandbox, appName)
+
+  // Upload agent config files (Claude, Codex, OpenCode) into the sandbox
+  const configFiles = await getAgentConfigFiles()
+  await Promise.allSettled(
+    configFiles.map(async ({ localPath, remotePath }) => {
+      const data = new Uint8Array(await Bun.file(localPath).arrayBuffer())
+      await provider.writeFile(remotePath, data)
+    }),
+  )
+
+  return provider
 }
 
 /**

--- a/src/lib/container-provider/modal.ts
+++ b/src/lib/container-provider/modal.ts
@@ -6,9 +6,9 @@
  */
 
 import { dirname, join, posix } from "node:path"
-import { readdir, stat } from "node:fs/promises"
+import { readdir } from "node:fs/promises"
 import { ModalClient, NotFoundError } from "modal"
-import { collectContainerEnv, checkAgentAuth, getAgentConfigFiles, type AgentAuthMethod } from "../agent-config.ts"
+import { collectContainerEnv, checkSandboxAgentAuth, getAgentConfigFiles, type AgentAuthMethod } from "../agent-config.ts"
 import type { Sandbox, Secret } from "modal"
 import type {
   ContainerProvider,
@@ -19,6 +19,7 @@ import type {
   UploadRepoOptions,
 } from "./types.ts"
 import { uploadRepoViaGitBundle } from "./sync.ts"
+import type { AgentProviderID } from "../agent/types.ts"
 
 export interface ModalProviderConfig {
   /** CPU cores for the sandbox (default: 2) */
@@ -120,14 +121,30 @@ export class ModalContainerProvider implements ContainerProvider {
   }
 
   async copyIn(localPath: string, remotePath: string): Promise<void> {
-    const info = await stat(localPath)
+    await this.copyInRecursive(localPath, remotePath, new Set())
+  }
+
+  private async copyInRecursive(
+    localPath: string,
+    remotePath: string,
+    visitedDirs: Set<string>,
+  ): Promise<void> {
+    const info = await Bun.file(localPath).stat()
 
     if (info.isDirectory()) {
+      const dirKey = `${info.dev}:${info.ino}`
+      if (visitedDirs.has(dirKey)) return
+      visitedDirs.add(dirKey)
+
       await this.sandbox.exec(["mkdir", "-p", remotePath], { stdout: "ignore", stderr: "ignore" })
       const entries = await readdir(localPath, { withFileTypes: true })
-      await Promise.all(entries.map((entry) =>
-        this.copyIn(join(localPath, entry.name), posix.join(remotePath, entry.name))
-      ))
+      for (const entry of entries) {
+        await this.copyInRecursive(
+          join(localPath, entry.name),
+          posix.join(remotePath, entry.name),
+          visitedDirs,
+        )
+      }
       return
     }
 
@@ -298,17 +315,19 @@ export async function lookupModalSandbox(
 }
 
 /**
- * Check if Modal auth environment variables are set.
- * This is a static check — does not make any API calls.
+ * Check if Modal auth env vars are set and the selected agent provider can
+ * authenticate inside the sandbox.
  */
-export function checkModalAuth(): { ok: boolean; error?: string; authMethod?: AgentAuthMethod } {
+export async function checkModalAuth(
+  provider: AgentProviderID = "claude",
+): Promise<{ ok: boolean; error?: string; authMethod?: AgentAuthMethod }> {
   if (!process.env.MODAL_TOKEN_ID || !process.env.MODAL_TOKEN_SECRET) {
     return {
       ok: false,
       error: "Set MODAL_TOKEN_ID and MODAL_TOKEN_SECRET environment variables (https://modal.com/settings)",
     }
   }
-  const agentAuth = checkAgentAuth()
+  const agentAuth = await checkSandboxAgentAuth(provider)
   if (!agentAuth.ok) return agentAuth
 
   return { ok: true, authMethod: agentAuth.authMethod }

--- a/src/lib/container-provider/sync.ts
+++ b/src/lib/container-provider/sync.ts
@@ -1,0 +1,119 @@
+import { lstat, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, posix, resolve, sep } from "node:path"
+import { bundleCreate, getCurrentBranch, getFullSha } from "../git.ts"
+import type { ExecOptions, UploadRepoOptions } from "./types.ts"
+
+const decoder = new TextDecoder()
+
+interface RepoUploadProvider {
+  exec(command: string[], opts?: ExecOptions): Promise<{ exitCode: number; stdout: Uint8Array; stderr: Uint8Array }>
+  copyIn(localPath: string, remotePath: string): Promise<void>
+}
+
+function decode(bytes: Uint8Array): string {
+  return decoder.decode(bytes).trim()
+}
+
+async function execChecked(
+  provider: RepoUploadProvider,
+  command: string[],
+  context: string,
+  opts?: ExecOptions,
+): Promise<string> {
+  const result = await provider.exec(command, opts)
+  if (result.exitCode !== 0) {
+    const output = decode(result.stderr.length > 0 ? result.stderr : result.stdout)
+    throw new Error(output ? `${context}: ${output}` : `${context}: exit ${result.exitCode}`)
+  }
+  return decode(result.stdout)
+}
+
+function resolveExtraCopyPath(localDir: string, relativePath: string): string {
+  const trimmed = relativePath.trim()
+  if (!trimmed || trimmed === ".") {
+    throw new Error(`Invalid extra copy path: ${JSON.stringify(relativePath)}`)
+  }
+
+  const repoRoot = resolve(localDir)
+  const absolutePath = resolve(repoRoot, trimmed)
+  if (absolutePath !== repoRoot && !absolutePath.startsWith(repoRoot + sep)) {
+    throw new Error(`Extra copy path must stay inside the repo root: ${relativePath}`)
+  }
+
+  return absolutePath
+}
+
+function toRemotePath(remoteDir: string, relativePath: string): string {
+  const normalized = relativePath.replaceAll("\\", "/")
+    .split("/")
+    .filter((segment) => segment && segment !== ".")
+  return posix.join(remoteDir, ...normalized)
+}
+
+export async function uploadRepoViaGitBundle(
+  provider: RepoUploadProvider,
+  localDir: string,
+  remoteDir: string,
+  options?: UploadRepoOptions,
+): Promise<void> {
+  const uploadId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const localBundleDir = await mkdtemp(join(tmpdir(), "autoauto-upload-"))
+  const localBundlePath = join(localBundleDir, "repo.bundle")
+  const remoteBundlePath = `/tmp/autoauto-upload-${uploadId}.bundle`
+  const remoteClonePath = `/tmp/autoauto-clone-${uploadId}`
+
+  try {
+    const [branch, localHead] = await Promise.all([
+      getCurrentBranch(localDir).catch(() => "HEAD"),
+      getFullSha(localDir),
+    ])
+
+    await bundleCreate(localDir, localBundlePath)
+    await provider.copyIn(localBundlePath, remoteBundlePath)
+
+    const remoteParent = posix.dirname(remoteDir)
+    if (remoteParent !== "/" && remoteParent !== ".") {
+      await execChecked(provider, ["mkdir", "-p", remoteParent], "Failed to prepare remote repo parent directory")
+    }
+
+    const cloneResult = await provider.exec(["git", "clone", remoteBundlePath, remoteClonePath])
+    if (cloneResult.exitCode !== 0) {
+      await provider.exec(["rm", "-rf", remoteClonePath]).catch(() => {})
+      await execChecked(provider, ["mkdir", "-p", remoteClonePath], "Failed to prepare fallback repo dir")
+      await execChecked(provider, ["git", "init"], "Failed to initialize fallback repo", { cwd: remoteClonePath })
+      await execChecked(provider, ["git", "bundle", "unbundle", remoteBundlePath], "Failed to restore repository from git bundle", { cwd: remoteClonePath })
+      await execChecked(provider, ["git", "checkout", "HEAD"], "Failed to checkout restored repository", { cwd: remoteClonePath })
+    }
+
+    if (branch !== "HEAD") {
+      await execChecked(provider, ["git", "checkout", branch], `Failed to checkout branch ${branch}`, { cwd: remoteClonePath })
+    }
+
+    await execChecked(
+      provider,
+      ["sh", "-c", 'rm -rf "$1" && mv "$2" "$1"', "sh", remoteDir, remoteClonePath],
+      "Failed to replace remote repository",
+    )
+
+    const extraCopyPaths = options?.extraCopyPaths ?? []
+    await Promise.all(extraCopyPaths.map(async (relativePath) => {
+      const localPath = resolveExtraCopyPath(localDir, relativePath)
+      try {
+        await lstat(localPath)
+      } catch {
+        return
+      }
+      await provider.copyIn(localPath, toRemotePath(remoteDir, relativePath))
+    }))
+
+    const remoteHead = await execChecked(provider, ["git", "rev-parse", "HEAD"], "Failed to verify uploaded repository", { cwd: remoteDir })
+    if (remoteHead !== localHead) {
+      throw new Error(`Uploaded repository HEAD mismatch: local=${localHead} remote=${remoteHead}`)
+    }
+  } finally {
+    await rm(localBundleDir, { recursive: true, force: true }).catch(() => {})
+    await provider.exec(["rm", "-f", remoteBundlePath]).catch(() => {})
+    await provider.exec(["rm", "-rf", remoteClonePath]).catch(() => {})
+  }
+}

--- a/src/lib/container-provider/types.ts
+++ b/src/lib/container-provider/types.ts
@@ -31,6 +31,11 @@ export interface ContainerHandle {
   attach(): Promise<ContainerProvider>
 }
 
+export interface UploadRepoOptions {
+  /** Extra repo-relative files or directories to copy after the git bundle restore. */
+  extraCopyPaths?: string[]
+}
+
 export interface ContainerProvider {
   /** Run a command to completion, collecting output */
   exec(command: string[], opts?: ExecOptions): Promise<ExecResult>
@@ -44,8 +49,11 @@ export interface ContainerProvider {
   /** Write a file to the container filesystem */
   writeFile(remotePath: string, data: Uint8Array | string): Promise<void>
 
-  /** Upload a local repo into the container (e.g. via git bundle) */
-  uploadRepo(localDir: string, remoteDir: string): Promise<void>
+  /** Copy a host file or directory into the container filesystem. */
+  copyIn(localPath: string, remotePath: string): Promise<void>
+
+  /** Upload a local repo into the container via git bundle, then optionally copy extra paths. */
+  uploadRepo(localDir: string, remoteDir: string, options?: UploadRepoOptions): Promise<void>
 
   /** Check if container is still running. Returns exit code if exited, null if alive. */
   poll(): Promise<number | null>

--- a/src/lib/run-backend/sandbox.ts
+++ b/src/lib/run-backend/sandbox.ts
@@ -232,6 +232,7 @@ export class SandboxRunBackend implements RunBackend {
     const provider = await this.providerFactory({
       programSlug: input.programSlug,
       runId,
+      mainRoot: input.mainRoot,
     })
 
     await provider.setMetadata({
@@ -239,7 +240,9 @@ export class SandboxRunBackend implements RunBackend {
       program_slug: input.programSlug,
     })
 
-    await provider.uploadRepo(input.mainRoot, REMOTE_WORKSPACE)
+    await provider.uploadRepo(input.mainRoot, REMOTE_WORKSPACE, {
+      extraCopyPaths: input.sandboxExtraCopyPaths,
+    })
 
     // --- Provisioning: install project dependencies ---
     // Check if a package.json/bun.lock exists before running install

--- a/src/lib/run-backend/types.ts
+++ b/src/lib/run-backend/types.ts
@@ -24,6 +24,8 @@ export interface SpawnRunInput {
   maxCostUsd?: number
   keepSimplifications?: boolean
   fallbackModel?: ModelSlot | null
+  /** Extra repo-relative files or directories to copy into sandbox runs after bundle restore. */
+  sandboxExtraCopyPaths?: string[]
 }
 
 /** Full state reconstructed from run files — used for attach/reconnect */

--- a/src/lib/user-auth.test.ts
+++ b/src/lib/user-auth.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  applyStoredAuthToEnv,
+  getUserAuthConfigPath,
+  loadUserAuthConfig,
+  saveClaudeCodeOAuthToken,
+} from "./user-auth.ts"
+
+let configHome: string
+let originalConfigHome: string | undefined
+let originalOauthToken: string | undefined
+let originalApiKey: string | undefined
+
+beforeEach(async () => {
+  configHome = await mkdtemp(join(tmpdir(), "autoauto-auth-"))
+  originalConfigHome = process.env.AUTOAUTO_CONFIG_HOME
+  originalOauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+  originalApiKey = process.env.ANTHROPIC_API_KEY
+  process.env.AUTOAUTO_CONFIG_HOME = configHome
+  delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+  delete process.env.ANTHROPIC_API_KEY
+})
+
+afterEach(async () => {
+  if (originalConfigHome === undefined) delete process.env.AUTOAUTO_CONFIG_HOME
+  else process.env.AUTOAUTO_CONFIG_HOME = originalConfigHome
+
+  if (originalOauthToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+  else process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOauthToken
+
+  if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY
+  else process.env.ANTHROPIC_API_KEY = originalApiKey
+
+  await rm(configHome, { recursive: true, force: true })
+})
+
+describe("user auth config", () => {
+  test("saves and loads a Claude OAuth token", async () => {
+    await saveClaudeCodeOAuthToken("  test-oauth-token  ")
+
+    const loaded = await loadUserAuthConfig()
+    expect(loaded.claudeCodeOAuthToken).toBe("test-oauth-token")
+
+    const raw = await Bun.file(getUserAuthConfigPath()).json() as { claudeCodeOAuthToken?: string }
+    expect(raw.claudeCodeOAuthToken).toBe("test-oauth-token")
+  })
+
+  test("applies a stored token to process.env when no env auth exists", async () => {
+    await saveClaudeCodeOAuthToken("persisted-token")
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+
+    await applyStoredAuthToEnv()
+
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("persisted-token")
+  })
+
+  test("does not override an existing API key", async () => {
+    await saveClaudeCodeOAuthToken("persisted-token")
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+    process.env.ANTHROPIC_API_KEY = "live-api-key"
+
+    await applyStoredAuthToEnv()
+
+    expect(process.env.ANTHROPIC_API_KEY).toBe("live-api-key")
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
+  })
+})

--- a/src/lib/user-auth.ts
+++ b/src/lib/user-auth.ts
@@ -1,0 +1,64 @@
+import { mkdir, rename, chmod } from "node:fs/promises"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+export interface UserAuthConfig {
+  claudeCodeOAuthToken?: string | null
+}
+
+function getUserConfigDir(): string {
+  if (process.env.AUTOAUTO_CONFIG_HOME) return process.env.AUTOAUTO_CONFIG_HOME
+  if (process.env.XDG_CONFIG_HOME) return join(process.env.XDG_CONFIG_HOME, "autoauto")
+  return join(homedir(), ".config", "autoauto")
+}
+
+export function getUserAuthConfigPath(): string {
+  return join(getUserConfigDir(), "auth.json")
+}
+
+export function formatUserAuthConfigPath(): string {
+  const path = getUserAuthConfigPath()
+  const home = homedir()
+  return path.startsWith(home) ? `~${path.slice(home.length)}` : path
+}
+
+export function hasClaudeEnvAuth(): boolean {
+  return Boolean(process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_CODE_OAUTH_TOKEN)
+}
+
+export async function loadUserAuthConfig(): Promise<UserAuthConfig> {
+  try {
+    const parsed = await Bun.file(getUserAuthConfigPath()).json() as Record<string, unknown>
+    return {
+      claudeCodeOAuthToken: typeof parsed.claudeCodeOAuthToken === "string"
+        ? parsed.claudeCodeOAuthToken
+        : null,
+    }
+  } catch {
+    return {}
+  }
+}
+
+export async function saveClaudeCodeOAuthToken(token: string): Promise<void> {
+  const normalized = token.trim()
+  if (!normalized) throw new Error("Claude token cannot be empty")
+
+  const dir = getUserConfigDir()
+  const path = getUserAuthConfigPath()
+  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`
+
+  await mkdir(dir, { recursive: true })
+  await Bun.write(tmpPath, JSON.stringify({ claudeCodeOAuthToken: normalized }, null, 2) + "\n")
+  await rename(tmpPath, path)
+  await chmod(path, 0o600).catch(() => {})
+
+  process.env.CLAUDE_CODE_OAUTH_TOKEN = normalized
+}
+
+export async function applyStoredAuthToEnv(): Promise<void> {
+  if (hasClaudeEnvAuth()) return
+
+  const config = await loadUserAuthConfig()
+  const token = config.claudeCodeOAuthToken?.trim()
+  if (token) process.env.CLAUDE_CODE_OAUTH_TOKEN = token
+}

--- a/src/screens/AuthErrorScreen.tsx
+++ b/src/screens/AuthErrorScreen.tsx
@@ -1,4 +1,5 @@
 import { colors } from "../lib/theme.ts"
+import { formatUserAuthConfigPath } from "../lib/user-auth.ts"
 
 export function AuthErrorScreen({ error }: { error: string }) {
   return (
@@ -19,8 +20,9 @@ export function AuthErrorScreen({ error }: { error: string }) {
       <box height={1} />
       <text>Run one of:</text>
       <text fg={colors.primary}>{"  claude login         (recommended)"}</text>
-      <text fg={colors.primary}>{"  claude setup-token   (API key)"}</text>
+      <text fg={colors.primary}>{"  claude setup-token   (long-lived token)"}</text>
       <box height={1} />
+      <text>{`You can also save the token in ${formatUserAuthConfigPath()} for future launches.`}</text>
       <text>Then restart AutoAuto.</text>
       {error && (
         <>

--- a/src/screens/FirstSetupScreen.tsx
+++ b/src/screens/FirstSetupScreen.tsx
@@ -19,6 +19,7 @@ import { CycleField } from "../components/CycleField.tsx"
 import { ModelPicker } from "../components/ModelPicker.tsx"
 import { resolveCompatibleModelSlot } from "../lib/model-options.ts"
 import { colors } from "../lib/theme.ts"
+import { formatUserAuthConfigPath, saveClaudeCodeOAuthToken } from "../lib/user-auth.ts"
 
 interface FirstSetupScreenProps {
   cwd: string
@@ -40,30 +41,78 @@ export function FirstSetupScreen({ cwd, navigate, onConfigChange }: FirstSetupSc
   const [pickingSlot, setPickingSlot] = useState<"support" | "execution" | null>(null)
   const [checking, setChecking] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [offerClaudeTokenSetup, setOfferClaudeTokenSetup] = useState(false)
+  const [editingClaudeToken, setEditingClaudeToken] = useState(false)
+  const [tokenInputKey, setTokenInputKey] = useState(0)
+
+  async function authenticateSelectedProviders(): Promise<{ ok: true } | { ok: false; provider: ModelSlot["provider"]; error: string }> {
+    const providers = [...new Set([supportSlot.provider, executionSlot.provider])]
+    const results = await Promise.all(
+      providers.map(async (provider) => ({ provider, result: await checkAuth(provider) })),
+    )
+    const failed = results.find(({ result }) => !result.authenticated)
+    if (!failed) return { ok: true }
+    const { result } = failed
+    return {
+      ok: false,
+      provider: failed.provider,
+      error: result.authenticated ? "Authentication failed" : result.error,
+    }
+  }
+
+  async function completeSetup() {
+    const config: ProjectConfig = {
+      executionModel: { ...executionSlot },
+      supportModel: { ...supportSlot },
+      ideasBacklogEnabled: true,
+      notificationPreset: "off",
+      notificationCommand: null,
+    }
+    await saveProjectConfig(cwd, config)
+    onConfigChange(config)
+    navigate("setup")
+  }
 
   async function handleContinue() {
     setChecking(true)
     setError(null)
+    setOfferClaudeTokenSetup(false)
     try {
-      const providers = new Set([supportSlot.provider, executionSlot.provider])
-      for (const provider of providers) {
-        const result = await checkAuth(provider)
-        if (!result.authenticated) {
-          setError(`${PROVIDER_LABELS[provider]}: ${result.error}`)
-          setChecking(false)
-          return
-        }
+      const auth = await authenticateSelectedProviders()
+      if (!auth.ok) {
+        setError(`${PROVIDER_LABELS[auth.provider]}: ${auth.error}`)
+        setOfferClaudeTokenSetup(auth.provider === "claude" && !process.env.ANTHROPIC_API_KEY)
+        setChecking(false)
+        return
       }
-      const config: ProjectConfig = {
-        executionModel: { ...executionSlot },
-        supportModel: { ...supportSlot },
-        ideasBacklogEnabled: true,
-        notificationPreset: "off",
-        notificationCommand: null,
+      await completeSetup()
+    } catch (err) {
+      setError(formatShellError(err))
+      setChecking(false)
+    }
+  }
+
+  async function handleClaudeTokenSubmit(value: unknown) {
+    if (typeof value !== "string") return
+    const token = value.trim()
+    if (!token) {
+      setError("Claude token cannot be empty")
+      return
+    }
+
+    setChecking(true)
+    setError(null)
+    try {
+      await saveClaudeCodeOAuthToken(token)
+      setEditingClaudeToken(false)
+      const auth = await authenticateSelectedProviders()
+      if (!auth.ok) {
+        setError(`${PROVIDER_LABELS[auth.provider]}: ${auth.error}`)
+        setOfferClaudeTokenSetup(auth.provider === "claude" && !process.env.ANTHROPIC_API_KEY)
+        setChecking(false)
+        return
       }
-      await saveProjectConfig(cwd, config)
-      onConfigChange(config)
-      navigate("setup")
+      await completeSetup()
     } catch (err) {
       setError(formatShellError(err))
       setChecking(false)
@@ -104,6 +153,17 @@ export function FirstSetupScreen({ cwd, navigate, onConfigChange }: FirstSetupSc
 
   useKeyboard((key) => {
     if (pickingSlot || checking) return
+    if (editingClaudeToken) {
+      if (key.name === "escape") {
+        setEditingClaudeToken(false)
+      }
+      return
+    }
+    if (offerClaudeTokenSetup && key.name === "t") {
+      setEditingClaudeToken(true)
+      setTokenInputKey((k) => k + 1)
+      return
+    }
     if (key.name === "up" || key.name === "k")
       setSelected((s) => Math.max(0, s - 1))
     if (key.name === "down" || key.name === "j")
@@ -207,6 +267,27 @@ export function FirstSetupScreen({ cwd, navigate, onConfigChange }: FirstSetupSc
           <box height={1} />
           <text fg={colors.error}>{`  Auth failed: ${error}`}</text>
           <text fg={colors.textMuted}>{"  Change provider or fix credentials, then try again."}</text>
+        </>
+      )}
+      {offerClaudeTokenSetup && (
+        <>
+          <box height={1} />
+          <text fg={colors.textMuted}>{"  No Claude subscription token is configured."}</text>
+          <text fg={colors.primary}>{"  Run: claude setup-token"}</text>
+          <text fg={colors.textMuted}>{`  Press t to paste it into AutoAuto and save it to ${formatUserAuthConfigPath()}`}</text>
+          {editingClaudeToken && (
+            <>
+              <box height={1} />
+              <box border borderStyle="rounded" height={3}>
+                <input
+                  key={tokenInputKey}
+                  focused
+                  placeholder="Paste CLAUDE_CODE_OAUTH_TOKEN and press Enter"
+                  onSubmit={handleClaudeTokenSubmit}
+                />
+              </box>
+            </>
+          )}
         </>
       )}
     </box>

--- a/src/screens/PreRunScreen.tsx
+++ b/src/screens/PreRunScreen.tsx
@@ -192,14 +192,14 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
 
     if (next === DOCKER_PROVIDER_ID) {
       import("../lib/container-provider/docker.ts").then(({ checkDockerAuth }) => {
-        checkDockerAuth().then(applySandboxAuth)
+        checkDockerAuth(modelSlot.provider).then(applySandboxAuth)
       })
       return
     }
 
     if (next === MODAL_PROVIDER_ID) {
       import("../lib/container-provider/modal.ts").then(({ checkModalAuth }) => {
-        applySandboxAuth(checkModalAuth())
+        checkModalAuth(modelSlot.provider).then(applySandboxAuth)
       })
     }
   }

--- a/src/screens/PreRunScreen.tsx
+++ b/src/screens/PreRunScreen.tsx
@@ -147,12 +147,14 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
 
   function handleStart() {
     if (programHasQueueEntries) return
+    if (sandboxAuthError) return
     const overrides = buildOverrides()
     if (overrides) onStart(overrides)
   }
 
   function handleAddToQueue() {
     if (!onAddToQueue) return
+    if (sandboxAuthError) return
     const overrides = buildOverrides()
     if (overrides) onAddToQueue(overrides)
   }
@@ -169,9 +171,9 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
 
   function handleCycleSandbox(direction: -1 | 1) {
     const next = cycleChoice(SANDBOX_CHOICES, sandboxChoice, direction)
+    setSandboxChoice(next)
 
     if (next === "off") {
-      setSandboxChoice("off")
       setSandboxAuthError(null)
       return
     }
@@ -181,10 +183,9 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
         checkDockerAuth().then((auth) => {
           if (!auth.ok) {
             setSandboxAuthError(auth.error ?? "Docker auth failed")
-            return
+          } else {
+            setSandboxAuthError(null)
           }
-          setSandboxAuthError(null)
-          setSandboxChoice(DOCKER_PROVIDER_ID)
         })
       })
       return
@@ -195,10 +196,9 @@ export function PreRunScreen({ cwd, programSlug, defaultModelConfig, navigate, o
         const auth = checkModalAuth()
         if (!auth.ok) {
           setSandboxAuthError(auth.error ?? "Modal auth failed")
-          return
+        } else {
+          setSandboxAuthError(null)
         }
-        setSandboxAuthError(null)
-        setSandboxChoice(MODAL_PROVIDER_ID)
       })
     }
   }


### PR DESCRIPTION
## Summary
- discover local Claude/Codex/OpenCode config and forward it into Docker and Modal sandboxes
- share git-bundle repo upload logic across container providers and support copying explicit extra paths after restore
- support project-specific `.autoauto/Dockerfile` images for Docker sandboxes and expand the mocked container test coverage

## Testing
- bun lint && bun typecheck
- bun test src/e2e/container-provider.e2e.test.ts src/e2e/sandbox-run-backend.e2e.test.ts
- bun test src/e2e/docker-integration.e2e.test.tsx *(currently errors locally because the test harness cannot resolve `react` in this checkout)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to copy additional repo files/directories into sandboxes/containers after upload.
  * Deterministic per-project Docker image builds (uses project Dockerfile when present).
  * Broader agent config discovery, now including Claude.

* **Bug Fixes**
  * Repo uploads use git-bundle transfers so only committed files are restored; untracked files and broken symlink extras are not copied.

* **Tests**
  * Added E2E coverage for extra-copy behavior and Docker build/exec workflows.

* **Style**
  * Updated sandbox warning glyphs and selection caret rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->